### PR TITLE
Add missing version bounds, make bounds DRY

### DIFF
--- a/beam.cabal
+++ b/beam.cabal
@@ -29,20 +29,20 @@ library
                        Database.Beam.Schema.Lenses
                        Database.Beam.Schema.Tables
                        Database.Beam.Schema.Fields
-  build-depends:       base         >=4.7  && <4.10
-                     , semigroups   >=0.13 && <0.19
-                     , mtl          >=2.2  && <2.3
-                     , containers   >=0.5  && <0.6
-                     , text         >=1.2  && <1.3
-                     , time         >=1.5  && <1.7
-                     , microlens    >=0.1  && <0.5
-                     , conduit      >=1.2  && <1.3
-                     , uniplate     >=1.6
-                     , tagged       >=0.7  && <0.9
-                     , convertible  >=1.1
-                     , pretty       >=1.1  && <1.2
-                     , HDBC         >=2.4
-                     , HDBC-sqlite3 >=2.3.3
+  build-depends:       HDBC         >=2.4   && <2.5
+                     , HDBC-sqlite3 >=2.3.3 && <2.4
+                     , base         >=4.7   && <4.10
+                     , conduit      >=1.2   && <1.3
+                     , containers   >=0.5   && <0.6
+                     , convertible  >=1.1   && <1.2
+                     , microlens    >=0.1   && <0.5
+                     , mtl          >=2.2   && <2.3
+                     , pretty       >=1.1   && <1.2
+                     , semigroups   >=0.13  && <0.19
+                     , tagged       >=0.7   && <0.9
+                     , text         >=1.2   && <1.3
+                     , time         >=1.5   && <1.7
+                     , uniplate     >=1.6   && <1.7
   hs-source-dirs:      src
   default-language:    Haskell2010
   default-extensions:  ScopedTypeVariables, OverloadedStrings, GADTs, RecursiveDo, FlexibleInstances, FlexibleContexts, TypeFamilies,
@@ -53,12 +53,12 @@ library
 executable beam-example
   main-is:             Employees.hs
   other-modules:       EmployeesData
-  build-depends:       base         >=4.7  && <4.10
+  build-depends:       base
                      , beam
-                     , mtl          >=2.2  && <2.3
-                     , text         >=1.2  && <1.3
-                     , time         >=1.5  && <1.7
-                     , microlens    >=0.1  && <0.5
+                     , microlens
+                     , mtl
+                     , text
+                     , time
   hs-source-dirs:      example
   default-language:    Haskell2010
   default-extensions:  ScopedTypeVariables, OverloadedStrings, GADTs, RecursiveDo, FlexibleInstances, FlexibleContexts, TypeFamilies,


### PR DESCRIPTION
Cabal only needs the version bounds specified once, which makes things less error prone in the future.