### PR TITLE
Fix "Ambiguous Occurrence 'C'"

### DIFF
--- a/beam-core/Database/Beam/Schema/Tables.hs
+++ b/beam-core/Database/Beam/Schema/Tables.hs
@@ -58,7 +58,7 @@ import qualified Data.Text as T
 import           Data.Typeable
 
 import qualified GHC.Generics as Generic
-import           GHC.Generics hiding (R)
+import           GHC.Generics hiding (R, C)
 import           GHC.TypeLits
 import           GHC.Types
 


### PR DESCRIPTION
```
Database/Beam/Schema/Tables.hs:28:17: error:
    Ambiguous occurrence ‘C’
    It could refer to either ‘GHC.Generics.C’,
                             imported from ‘GHC.Generics’ at Database/Beam/Schema/Tables.hs:61:1-40
                          or ‘Database.Beam.Schema.Tables.C’,
                             defined at Database/Beam/Schema/Tables.hs:264:1
```

looks like it was introduced by 0c1ee6992e0d852c303313a7e529a24df9742d62