### PR TITLE
Use https for fetching jquery dep

### DIFF
--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -7,7 +7,7 @@
 
 {% block scripts %}
 {{ super() }}
-<script type="text/javascript" language="javascript"  src="http://code.jquery.com/jquery-2.2.4.min.js"></script>
+<script type="text/javascript" language="javascript"  src="https://code.jquery.com/jquery-2.2.4.min.js"></script>
 <script type="text/javascript" language="javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
 <script type="text/javascript" language="javascript">
  $(document.body).tab();


### PR DESCRIPTION
Should fix the following errors in console and toggling examples
```
tathougies.github.io/:1 Mixed Content: The page at 'https://tathougies.github.io/beam/' was loaded over HTTPS, but requested an insecure script 'http://code.jquery.com/jquery-2.2.4.min.js'. This request has been blocked; the content must be served over HTTPS.
bootstrap.min.js:6 Uncaught Error: Bootstrap's JavaScript requires jQuery
    at bootstrap.min.js:6
tathougies.github.io/:1036 Uncaught ReferenceError: $ is not defined
    at tathougies.github.io/:1036
beam.css Failed to load resource: the server responded with a status of 404 ()
```