### PR TITLE
updating docs for installing until released on hackage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -43,8 +43,9 @@ packages:
     - <backend>
 ```
 
-NB: the commit will need to be changed to whatever the latest commit of master
-is, or whichever commit you want to build from even.
+!!! note "Note"
+    the commit will need to be changed to whatever the latest commit of master is,
+    or whichever commit you want to build from even.
 
 and add the following to your `.cabal` file, in the `build-depends` section:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,21 +27,34 @@ Beam features
 
 ## How to install
 
-Beam is available via both [Hackage](https://hackage.haskell.org/packages/beam)
-and [Stack](https://www.stackage.org/package/beam). For most Haskell
-installations, one of the two commands should work.
+Beam **isnt** available via Hackage *or* Stack. Until a release is cut, put the
+following in your `stack.yaml` to build and use beam in your project!
 
-```bash
-cabal install beam-core beam-migrate <backend>
+```yaml
+packages:
+- .
+- location:
+    git: https://github.com/tathougies/beam.git
+    commit: a3b5e0763843fed48c7eef53fa7d08cfe710342d
+  extra-dep: true
+  subdirs:
+    - beam-core
+    - beam-migrate
+    - <backend>
 ```
 
-or
+NB: the commit will need to be changed to whatever the latest commit of master
+is, or whichever commit you want to build from even.
 
-```
-stack install beam-core beam-migrate <backend>
+and add the following to your `.cabal` file, in the `build-depends` section:
+
+```haskell
+beam-core,
+beam-migrate,
+<backend>
 ```
 
-You will also need to install an appropriate backend. Available backends are
+Available backends are:
 
 * `beam-postgres` -- A feature-complete backend for the Postgres RDBMS.
   See [the beam-postgres documentation](user-guide/backends/beam-postgres.md)


### PR DESCRIPTION
Just adding some docs to use in a project since beam isn't realeased to stackage yet.

just use the stack file to pull directly from master to whichever commit you
would like.

After that, add beam-core, beam-migrate, and the backend of your choice
[postgres|sqlite] (to your cabal file)