### PR TITLE
Widen dlist lower bound

### DIFF
--- a/beam-core/beam-core.cabal
+++ b/beam-core/beam-core.cabal
@@ -45,20 +45,20 @@ library
                        Database.Beam.Query.Aggregate
 
                        Database.Beam.Schema.Lenses
-  build-depends:       base        >=4.7  && <5.0,
-                       aeson       >=0.11 && <1.3,
-                       text        >=1.0  && <1.3,
-                       bytestring  >=0.10 && <0.11,
-                       mtl         >=2.1  && <2.3,
-                       microlens   >=0.4  && <0.5,
-                       ghc-prim    >=0.5  && <0.6,
-                       free        >=4.12 && <4.13,
-                       dlist       >=0.8  && <0.9,
-                       time        >=1.6  && <1.10,
-                       hashable    >=1.1  && <1.3,
-                       network-uri >=2.6  && <2.7,
-                       containers  >=0.5  && <0.6,
-                       vector-sized >=0.5 && <0.7
+  build-depends:       base         >=4.7     && <5.0,
+                       aeson        >=0.11    && <1.3,
+                       text         >=1.0     && <1.3,
+                       bytestring   >=0.10    && <0.11,
+                       mtl          >=2.1     && <2.3,
+                       microlens    >=0.4     && <0.5,
+                       ghc-prim     >=0.5     && <0.6,
+                       free         >=4.12    && <4.13,
+                       dlist        >=0.7.1.2 && <0.9,
+                       time         >=1.6     && <1.10,
+                       hashable     >=1.1     && <1.3,
+                       network-uri  >=2.6     && <2.7,
+                       containers   >=0.5     && <0.6,
+                       vector-sized >=0.5     && <0.7
   Default-language:    Haskell2010
   default-extensions:  ScopedTypeVariables, OverloadedStrings, GADTs, RecursiveDo, FlexibleInstances, FlexibleContexts, TypeFamilies,
                        GeneralizedNewtypeDeriving, RankNTypes, TupleSections, ConstraintKinds, StandaloneDeriving, TypeOperators,


### PR DESCRIPTION
Things appear to work with wider `dlist` bounds. I needed this because `reflex-platform`'s `ghcjs` package set is currently stuck on dlist 7.2.1. If you'd rather not merge this in order to minimize your compatibility "footprint", I can work around it easily on my end. But I figured I'd offer it as a change in case you want it.