### PR TITLE
postgres json[b] needs to be single quoted for postgres to not complain

### DIFF
--- a/beam-postgres/Database/Beam/Postgres/PgSpecific.hs
+++ b/beam-postgres/Database/Beam/Postgres/PgSpecific.hs
@@ -221,7 +221,7 @@ instance (Typeable a, FromJSON a) => FromBackendRow Postgres (PgJSON a)
 instance ToJSON a => HasSqlValueSyntax PgValueSyntax (PgJSON a) where
   sqlValueSyntax (PgJSON a) =
     PgValueSyntax $
-    escapeString (BL.toStrict (encode a)) <> emit "::json"
+    emit "'" <> escapeString (BL.toStrict (encode a)) <> emit "'::json"
 
 newtype PgJSONB a = PgJSONB a
   deriving ( Show, Eq, Ord, Hashable, Monoid )
@@ -238,7 +238,7 @@ instance (Typeable a, FromJSON a) => FromBackendRow Postgres (PgJSONB a)
 instance ToJSON a => HasSqlValueSyntax PgValueSyntax (PgJSONB a) where
   sqlValueSyntax (PgJSONB a) =
     PgValueSyntax $
-    escapeString (BL.toStrict (encode a)) <> emit "::jsonb"
+    emit "'" <> escapeString (BL.toStrict (encode a)) <> emit "'::jsonb"
 
 class IsPgJSON (json :: * -> *) where
 --  pgJsonEach     :: QGenExpr ctxt PgExpressionSyntax s (json a) -> Q PgSelectSyntax s (PgJSONTable (QGenExpr ctxt PgExpressionSyntax s))


### PR DESCRIPTION
I noticed this trying to insert a jsonb into a table

with debug mode on, I can see the sql generated as

```sql
INSERT INTO "some_table"
("some_jsonb") 
VALUES 
([{"task":"do the other thing"}]::jsonb), ([{"task":"do this other thing"}]::jsonb)
```

```text
*** Exception: SqlError {sqlState = "42601", sqlExecStatus = FatalError, sqlErrorMsg = "syntax error at or near \"[\"", sqlErrorDetail = "", sqlErrorHint = ""}
```

and perusing the [postgres json docs](https://www.postgresql.org/docs/9.6/static/datatype-json.html) I could see that beam is missing the single quotes

```sql
SELECT '{"bar": "baz", "balance": 7.77, "active":false}'::json;
```

I'm using postgres `9.6.5`, and this fixes the errors for me.  Wondering if you can check on your machine?

Also I know there aren't any tests for a change like this... would you want to start small with tests for these changes and provide some guidance on how to do so? 