### PR TITLE
Fix warning: export `Database.Beam.Migrate.Backend`.

### DIFF
--- a/beam-migrate/beam-migrate.cabal
+++ b/beam-migrate/beam-migrate.cabal
@@ -23,6 +23,7 @@ library
 
                        Database.Beam.Migrate.Checks
                        Database.Beam.Migrate.Actions
+                       Database.Beam.Migrate.Backend
 
                        Database.Beam.Migrate.SQL
                        Database.Beam.Migrate.SQL.Types


### PR DESCRIPTION
It previously was listed in neither `exposed-modules` nor `other-modules`, but
*was* re-exported through the top-level module `Database.Beam.Migrate`.

Warning was:
```
Warning: The following modules should be added to exposed-modules or other-modules in /Users/judah.jacobson/repos/beam/beam-migrate/beam-migrate.cabal:
    - In the library component:
        Database.Beam.Migrate.Backend

Missing modules in the cabal file are likely to cause undefined reference errors from the linker, along with other problems.
```

(In this case it seemed to not cause problems because that module only defined
data types.)