### PR TITLE
Export IsCustomExprFn

### DIFF
--- a/beam-core/Database/Beam/Query/CustomSQL.hs
+++ b/beam-core/Database/Beam/Query/CustomSQL.hs
@@ -16,7 +16,8 @@
 module Database.Beam.Query.CustomSQL
   (
   -- * The 'customExpr_' function
-    customExpr_
+    IsCustomExprFn(..)
+
   -- ** Type-inference help
   , valueExpr_, agg_
 


### PR DESCRIPTION
This makes it possible to write down the type inferred for `customExpr_` expressions.