### PR TITLE
Allow up to 12-tuples in results

### DIFF
--- a/beam-core/Database/Beam/Backend/Types.hs
+++ b/beam-core/Database/Beam/Backend/Types.hs
@@ -164,6 +164,53 @@ instance ( BeamBackend be
   valuesNeeded be _ = valuesNeeded be (Proxy @a) + valuesNeeded be (Proxy @b) + valuesNeeded be (Proxy @c) + valuesNeeded be (Proxy @d) +
                       valuesNeeded be (Proxy @e) + valuesNeeded be (Proxy @f) + valuesNeeded be (Proxy @g) + valuesNeeded be (Proxy @h)
 
+instance ( BeamBackend be
+         , FromBackendRow be a, FromBackendRow be b, FromBackendRow be c
+         , FromBackendRow be d, FromBackendRow be e, FromBackendRow be f
+         , FromBackendRow be g, FromBackendRow be h, FromBackendRow be i ) =>
+  FromBackendRow be (a, b, c, d, e, f, g, h, i) where
+  fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep ( Exposed a, Exposed b, Exposed c, Exposed d, Exposed e, Exposed f, Exposed g, Exposed h
+                                                       , Exposed i)))
+  valuesNeeded be _ = valuesNeeded be (Proxy @a) + valuesNeeded be (Proxy @b) + valuesNeeded be (Proxy @c) + valuesNeeded be (Proxy @d) +
+                      valuesNeeded be (Proxy @e) + valuesNeeded be (Proxy @f) + valuesNeeded be (Proxy @g) + valuesNeeded be (Proxy @h) +
+                      valuesNeeded be (Proxy @i)
+
+instance ( BeamBackend be
+         , FromBackendRow be a, FromBackendRow be b, FromBackendRow be c
+         , FromBackendRow be d, FromBackendRow be e, FromBackendRow be f
+         , FromBackendRow be g, FromBackendRow be h, FromBackendRow be i
+         , FromBackendRow be j ) =>
+  FromBackendRow be (a, b, c, d, e, f, g, h, i, j) where
+  fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep ( Exposed a, Exposed b, Exposed c, Exposed d, Exposed e, Exposed f, Exposed g, Exposed h
+                                                       , Exposed i, Exposed j)))
+  valuesNeeded be _ = valuesNeeded be (Proxy @a) + valuesNeeded be (Proxy @b) + valuesNeeded be (Proxy @c) + valuesNeeded be (Proxy @d) +
+                      valuesNeeded be (Proxy @e) + valuesNeeded be (Proxy @f) + valuesNeeded be (Proxy @g) + valuesNeeded be (Proxy @h) +
+                      valuesNeeded be (Proxy @i) + valuesNeeded be (Proxy @j)
+
+instance ( BeamBackend be
+         , FromBackendRow be a, FromBackendRow be b, FromBackendRow be c
+         , FromBackendRow be d, FromBackendRow be e, FromBackendRow be f
+         , FromBackendRow be g, FromBackendRow be h, FromBackendRow be i
+         , FromBackendRow be j, FromBackendRow be k) =>
+  FromBackendRow be (a, b, c, d, e, f, g, h, i, j, k) where
+  fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep ( Exposed a, Exposed b, Exposed c, Exposed d, Exposed e, Exposed f, Exposed g, Exposed h
+                                                       , Exposed i, Exposed j, Exposed k)))
+  valuesNeeded be _ = valuesNeeded be (Proxy @a) + valuesNeeded be (Proxy @b) + valuesNeeded be (Proxy @c) + valuesNeeded be (Proxy @d) +
+                      valuesNeeded be (Proxy @e) + valuesNeeded be (Proxy @f) + valuesNeeded be (Proxy @g) + valuesNeeded be (Proxy @h) +
+                      valuesNeeded be (Proxy @i) + valuesNeeded be (Proxy @j) + valuesNeeded be (Proxy @k)
+
+instance ( BeamBackend be
+         , FromBackendRow be a, FromBackendRow be b, FromBackendRow be c
+         , FromBackendRow be d, FromBackendRow be e, FromBackendRow be f
+         , FromBackendRow be g, FromBackendRow be h, FromBackendRow be i
+         , FromBackendRow be j, FromBackendRow be k, FromBackendRow be l ) =>
+  FromBackendRow be (a, b, c, d, e, f, g, h, i, j, k, l) where
+  fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep ( Exposed a, Exposed b, Exposed c, Exposed d, Exposed e, Exposed f, Exposed g, Exposed h
+                                                       , Exposed i, Exposed j, Exposed k, Exposed l)))
+  valuesNeeded be _ = valuesNeeded be (Proxy @a) + valuesNeeded be (Proxy @b) + valuesNeeded be (Proxy @c) + valuesNeeded be (Proxy @d) +
+                      valuesNeeded be (Proxy @e) + valuesNeeded be (Proxy @f) + valuesNeeded be (Proxy @g) + valuesNeeded be (Proxy @h) +
+                      valuesNeeded be (Proxy @i) + valuesNeeded be (Proxy @j) + valuesNeeded be (Proxy @k) + valuesNeeded be (Proxy @l)
+
 instance ( BeamBackend be, Generic (tbl Identity), Generic (tbl Exposed)
          , GFromBackendRow be (Rep (tbl Exposed)) (Rep (tbl Identity))) =>
 
@@ -187,3 +234,7 @@ instance (BeamBackend be, FromBackendRow be (Maybe x)) => FromBackendRow be (Aut
   valuesNeeded be _ = valuesNeeded be (Proxy @(Maybe x))
 
 deriving instance Generic (a, b, c, d, e, f, g, h)
+deriving instance Generic (a, b, c, d, e, f, g, h, i)
+deriving instance Generic (a, b, c, d, e, f, g, h, i, j)
+deriving instance Generic (a, b, c, d, e, f, g, h, i, j, k)
+deriving instance Generic (a, b, c, d, e, f, g, h, i, j, k, l)

--- a/beam-core/Database/Beam/Query/Internal.hs
+++ b/beam-core/Database/Beam/Query/Internal.hs
@@ -471,6 +471,50 @@ instance ( ProjectibleWithPredicate contextPredicate syntax a, ProjectibleWithPr
     (,,,,,,,) <$> project' p mkE a <*> project' p mkE b <*> project' p mkE c
               <*> project' p mkE d <*> project' p mkE e <*> project' p mkE f
               <*> project' p mkE g <*> project' p mkE h
+instance ( ProjectibleWithPredicate contextPredicate syntax a, ProjectibleWithPredicate contextPredicate syntax b, ProjectibleWithPredicate contextPredicate syntax c
+         , ProjectibleWithPredicate contextPredicate syntax d, ProjectibleWithPredicate contextPredicate syntax e, ProjectibleWithPredicate contextPredicate syntax f
+         , ProjectibleWithPredicate contextPredicate syntax g, ProjectibleWithPredicate contextPredicate syntax h, ProjectibleWithPredicate contextPredicate syntax i ) =>
+  ProjectibleWithPredicate contextPredicate syntax (a, b, c, d, e, f, g, h, i) where
+
+  project' p mkE (a, b, c, d, e, f, g, h, i) =
+    (,,,,,,,,) <$> project' p mkE a <*> project' p mkE b <*> project' p mkE c
+               <*> project' p mkE d <*> project' p mkE e <*> project' p mkE f
+               <*> project' p mkE g <*> project' p mkE h <*> project' p mkE i
+instance ( ProjectibleWithPredicate contextPredicate syntax a, ProjectibleWithPredicate contextPredicate syntax b, ProjectibleWithPredicate contextPredicate syntax c
+         , ProjectibleWithPredicate contextPredicate syntax d, ProjectibleWithPredicate contextPredicate syntax e, ProjectibleWithPredicate contextPredicate syntax f
+         , ProjectibleWithPredicate contextPredicate syntax g, ProjectibleWithPredicate contextPredicate syntax h, ProjectibleWithPredicate contextPredicate syntax i
+         , ProjectibleWithPredicate contextPredicate syntax j ) =>
+  ProjectibleWithPredicate contextPredicate syntax (a, b, c, d, e, f, g, h, i, j) where
+
+  project' p mkE (a, b, c, d, e, f, g, h, i, j) =
+    (,,,,,,,,,) <$> project' p mkE a <*> project' p mkE b <*> project' p mkE c
+                <*> project' p mkE d <*> project' p mkE e <*> project' p mkE f
+                <*> project' p mkE g <*> project' p mkE h <*> project' p mkE i
+                <*> project' p mkE j
+instance ( ProjectibleWithPredicate contextPredicate syntax a, ProjectibleWithPredicate contextPredicate syntax b, ProjectibleWithPredicate contextPredicate syntax c
+         , ProjectibleWithPredicate contextPredicate syntax d, ProjectibleWithPredicate contextPredicate syntax e, ProjectibleWithPredicate contextPredicate syntax f
+         , ProjectibleWithPredicate contextPredicate syntax g, ProjectibleWithPredicate contextPredicate syntax h, ProjectibleWithPredicate contextPredicate syntax i
+         , ProjectibleWithPredicate contextPredicate syntax j, ProjectibleWithPredicate contextPredicate syntax k ) =>
+  ProjectibleWithPredicate contextPredicate syntax (a, b, c, d, e, f, g, h, i, j, k) where
+
+  project' p mkE (a, b, c, d, e, f, g, h, i, j, k) =
+    (,,,,,,,,,,) <$> project' p mkE a <*> project' p mkE b <*> project' p mkE c
+                 <*> project' p mkE d <*> project' p mkE e <*> project' p mkE f
+                 <*> project' p mkE g <*> project' p mkE h <*> project' p mkE i
+                 <*> project' p mkE j <*> project' p mkE k
+instance ( ProjectibleWithPredicate contextPredicate syntax a, ProjectibleWithPredicate contextPredicate syntax b, ProjectibleWithPredicate contextPredicate syntax c
+         , ProjectibleWithPredicate contextPredicate syntax d, ProjectibleWithPredicate contextPredicate syntax e, ProjectibleWithPredicate contextPredicate syntax f
+         , ProjectibleWithPredicate contextPredicate syntax g, ProjectibleWithPredicate contextPredicate syntax h, ProjectibleWithPredicate contextPredicate syntax i
+         , ProjectibleWithPredicate contextPredicate syntax j, ProjectibleWithPredicate contextPredicate syntax k, ProjectibleWithPredicate contextPredicate syntax l ) =>
+  ProjectibleWithPredicate contextPredicate syntax (a, b, c, d, e, f, g, h, i, j, k, l) where
+
+  project' p mkE (a, b, c, d, e, f, g, h, i, j, k, l) =
+    (,,,,,,,,,,,) <$> project' p mkE a <*> project' p mkE b <*> project' p mkE c
+                  <*> project' p mkE d <*> project' p mkE e <*> project' p mkE f
+                  <*> project' p mkE g <*> project' p mkE h <*> project' p mkE i
+                  <*> project' p mkE j <*> project' p mkE k <*> project' p mkE l
+
+
 
 project :: Projectible syntax a => a -> WithExprContext [ syntax ]
 project = sequenceA . DList.toList . execWriter . project' (Proxy @AnyType) (\_ e -> tell (DList.singleton e) >> pure e)

--- a/beam-core/Database/Beam/Query/Types.hs
+++ b/beam-core/Database/Beam/Query/Types.hs
@@ -33,6 +33,18 @@ type instance QExprToIdentity (a, b, c, d, e, f, g) =
 type instance QExprToIdentity (a, b, c, d, e, f, g, h) =
   ( QExprToIdentity a, QExprToIdentity b, QExprToIdentity c, QExprToIdentity d, QExprToIdentity e, QExprToIdentity f
   , QExprToIdentity g, QExprToIdentity h )
+type instance QExprToIdentity (a, b, c, d, e, f, g, h, i) =
+  ( QExprToIdentity a, QExprToIdentity b, QExprToIdentity c, QExprToIdentity d, QExprToIdentity e, QExprToIdentity f
+  , QExprToIdentity g, QExprToIdentity h, QExprToIdentity i )
+type instance QExprToIdentity (a, b, c, d, e, f, g, h, i, j) =
+  ( QExprToIdentity a, QExprToIdentity b, QExprToIdentity c, QExprToIdentity d, QExprToIdentity e, QExprToIdentity f
+  , QExprToIdentity g, QExprToIdentity h, QExprToIdentity i, QExprToIdentity j)
+type instance QExprToIdentity (a, b, c, d, e, f, g, h, i, j, k) =
+  ( QExprToIdentity a, QExprToIdentity b, QExprToIdentity c, QExprToIdentity d, QExprToIdentity e, QExprToIdentity f
+  , QExprToIdentity g, QExprToIdentity h, QExprToIdentity i, QExprToIdentity j, QExprToIdentity k)
+type instance QExprToIdentity (a, b, c, d, e, f, g, h, i, j, k, l) =
+  ( QExprToIdentity a, QExprToIdentity b, QExprToIdentity c, QExprToIdentity d, QExprToIdentity e, QExprToIdentity f
+  , QExprToIdentity g, QExprToIdentity h, QExprToIdentity i, QExprToIdentity j, QExprToIdentity k, QExprToIdentity l )
 type instance QExprToIdentity (Vector n a) = Vector n (QExprToIdentity a)
 
 class IsSql92SelectSyntax selectSyntax => HasQBuilder selectSyntax where


### PR DESCRIPTION
There seems to be a limit of 8 on the size of tuples that can be returned as results. I ran into this by accident with a query that returns a 9-tuple. This adds instances needed to handle up to 12.

Don't need to go there just yet but all things considered could this be a valid exception from the non-TH rule?