### PR TITLE
Explicit equality, remove Auto, and update docs

### DIFF
--- a/beam-core/ChangeLog.md
+++ b/beam-core/ChangeLog.md
@@ -1,3 +1,61 @@
+# 0.7.0.0
+
+## Require backends to explicitly declare types that can be compared for equality
+
+Beam previously allowed any two types to be compared for SQL
+equality. This is no longer the case. Rather, only types that are
+instances of `HasSqlEqualityCheck` for the given expression syntax can
+be checked for equality. Correspondingly, only types that are
+instances of `HasSqlQuantifiedEqualityCheck` can be checked for
+quantified equality.
+
+This change is somewhat invasive, as the relationship and join
+operators depend on the ability to check primary keys for
+equality. You may have to add appropriate class constraints to your
+queries. In order to assert that a table can be compared for equality,
+you can use the `HasTableEquality` constraint synonym.
+
+### For Backends
+
+Backend implementors should establish instances of
+`HasSqlEqualityCheck` and `HasSqlQuantifiedEqualityCheck` for every
+type that can be compared in their syntax. You may choose to implement
+a custom equality and inequality operator. Alternatively, you can
+leave the instances empty to use the defaults, which match the old
+behavior.
+
+## Properly deal with NULL values in equality
+
+Previous versions of Beam would use SQL `=` and `<>` operators to
+compare potentially `NULL` values. However, `NULL = NULL` is always
+false, according to the SQL standard, so this behavior is incorrect.
+
+Now, Beam will generate a `CASE .. WHEN ..` statement to explicitly
+handle mismatching `NULL`s. This is the 'expected' behavior from the
+Haskell perspective, but does not match what one may expect in
+SQL. Note that it is always better to explicitly handle `NULL`s using
+`maybe_`, and beam recommends this approach in robust code.
+
+## Remove `Auto` for fields with default values
+
+`Auto` was a convenience type for dealing with tables where some
+columns have been given a default value. `Auto` worked well enough but
+it was a very leaky abstraction. Moreover, it was
+unnecessary. Everything you can do with `Auto` can be done more safely
+with `default_`.
+
+For example, instead of using
+
+```haskell
+insertValues [ Table1 (Auto Nothing) "Field Value" "Another Field Value" ]
+```
+
+use
+
+```haskell
+insertExpressions [ Table1 default_ (val_ "Field Value") (val_ "Another Field Value") ]
+```
+
 # 0.6.0.0
 
 * Mostly complete SQL92, SQL99 support

--- a/beam-core/Database/Beam.hs
+++ b/beam-core/Database/Beam.hs
@@ -12,7 +12,6 @@ module Database.Beam
      ( module Database.Beam.Query
      , module Database.Beam.Schema
      , MonadBeam(withDatabase, withDatabaseDebug)
-     , Auto(..)
      , FromBackendRow(..)
 
        -- * Re-exports

--- a/beam-core/Database/Beam/Backend/SQL/AST.hs
+++ b/beam-core/Database/Beam/Backend/SQL/AST.hs
@@ -10,7 +10,6 @@ import Database.Beam.Backend.SQL.SQL92
 import Database.Beam.Backend.SQL.SQL99
 import Database.Beam.Backend.SQL.SQL2003
 import Database.Beam.Backend.SQL.Types
-import Database.Beam.Backend.Types
 
 import Data.Text (Text)
 import Data.ByteString (ByteString)
@@ -506,9 +505,6 @@ instance HasSqlValueSyntax Value x => HasSqlValueSyntax Value (Maybe x) where
   sqlValueSyntax (Just x) = sqlValueSyntax x
   sqlValueSyntax Nothing = sqlValueSyntax SqlNull
 
-instance HasSqlValueSyntax Value (Maybe x) => HasSqlValueSyntax Value (Auto x) where
-  sqlValueSyntax (Auto x) = sqlValueSyntax x
-
 instance Eq Value where
   Value a == Value b =
     case cast a of
@@ -556,3 +552,4 @@ data WindowFrameBound
 instance IsSql2003WindowFrameBoundSyntax WindowFrameBound where
   unboundedSyntax = WindowFrameUnbounded
   nrowsBoundSyntax = WindowFrameBoundNRows
+

--- a/beam-core/Database/Beam/Backend/Types.hs
+++ b/beam-core/Database/Beam/Backend/Types.hs
@@ -5,7 +5,6 @@
 
 module Database.Beam.Backend.Types
   ( BeamBackend(..)
-  , Auto(..)
 
   , FromBackendRowF(..), FromBackendRowM
   , parseOneField, peekField, checkNextNNull
@@ -31,26 +30,6 @@ import GHC.Types
 class BeamBackend be where
   -- | Requirements to marshal a certain type from a database of a particular backend
   type BackendFromField be :: * -> Constraint
-
--- | Newtype wrapper for types that may be given default values by the database.
---   Essentially, a wrapper around 'Maybe x'.
---
---   When a value of type 'Auto x' is written to a database (via @INSERT@ or
---   @UPDATE@, for example), backends will translate a 'Nothing' value into an
---   expression that will evaluate to whatever default value the database would
---   choose. This is useful to insert rows with columns that are
---   auto-incrementable or have a @DEFAULT@ value.
---
---   When read from the database, the wrapped value will always be a 'Just'
---   value. This isn't currently enforced at the type-level, but may be in
---   future versions of beam.
-newtype Auto x = Auto { unAuto :: Maybe x }
-  deriving (Show, Read, Eq, Ord, Generic, Monoid)
-instance Json.FromJSON a => Json.FromJSON (Auto a) where
-  parseJSON a = Auto <$> Json.parseJSON a
-instance Json.ToJSON a => Json.ToJSON (Auto a) where
-  toJSON (Auto a) = Json.toJSON a
-  toEncoding (Auto a) = Json.toEncoding a
 
 data FromBackendRowF be f where
   ParseOneField :: BackendFromField be a => (a -> f) -> FromBackendRowF be f
@@ -183,9 +162,6 @@ instance FromBackendRow be x => FromBackendRow be (Maybe x) where
     do isNull <- checkNextNNull (valuesNeeded (Proxy @be) (Proxy @(Maybe x)))
        if isNull then pure Nothing else Just <$> fromBackendRow
   valuesNeeded be _ = valuesNeeded be (Proxy @x)
-instance (BeamBackend be, FromBackendRow be (Maybe x)) => FromBackendRow be (Auto x) where
-  fromBackendRow = Auto <$> fromBackendRow
-  valuesNeeded be _ = valuesNeeded be (Proxy @(Maybe x))
 
 deriving instance Generic (a, b, c, d, e, f, g, h)
 

--- a/beam-core/Database/Beam/Query.hs
+++ b/beam-core/Database/Beam/Query.hs
@@ -25,6 +25,8 @@ module Database.Beam.Query
     -- * Operators
     , module Database.Beam.Query.Operator
 
+    , HasSqlEqualityCheck(..), HasSqlQuantifiedEqualityCheck(..)
+
     -- ** Unquantified comparison operators
     , SqlEq(..), SqlOrd(..)
 
@@ -126,6 +128,8 @@ lookup :: ( HasQBuilder syntax
           , SqlValableTable (PrimaryKey table) (Sql92SelectExpressionSyntax syntax)
           , HasSqlValueSyntax (Sql92ExpressionValueSyntax (Sql92SelectExpressionSyntax syntax)) Bool
 
+          , HasTableEquality (Sql92SelectExpressionSyntax syntax) (PrimaryKey table)
+
           , Beamable table, Table table
 
           , Database db )
@@ -175,6 +179,7 @@ insert :: IsSql92InsertSyntax syntax =>
        -> SqlInsertValues (Sql92InsertValuesSyntax syntax) table
           -- ^ Values to insert. See 'insertValues', 'insertExpressions', and 'insertFrom' for possibilities.
        -> SqlInsert syntax
+insert _ SqlInsertValuesEmpty = SqlInsertNoRows
 insert (DatabaseEntity (DatabaseTable tblNm tblSettings)) (SqlInsertValues vs) =
     SqlInsert (insertStmt tblNm tblFields vs)
   where
@@ -183,7 +188,7 @@ insert (DatabaseEntity (DatabaseTable tblNm tblSettings)) (SqlInsertValues vs) =
 -- | Run a 'SqlInsert' in a 'MonadBeam'
 runInsert :: (IsSql92Syntax cmd, MonadBeam cmd be hdl m)
           => SqlInsert (Sql92InsertSyntax cmd) -> m ()
-runInsert SqlInsertNoRows = pure ()          
+runInsert SqlInsertNoRows = pure ()
 runInsert (SqlInsert i) = runNoReturn (insertCmd i)
 
 -- | Represents a source of values that can be inserted into a table shaped like
@@ -205,7 +210,7 @@ insertExpressions tbls =
     _  -> SqlInsertValues (insertSqlExpressions sqlExprs)
     where
       sqlExprs = map mkSqlExprs tbls
-      
+
       mkSqlExprs :: forall s. table (QExpr (Sql92InsertValuesExpressionSyntax syntax) s) -> [Sql92InsertValuesExpressionSyntax syntax]
       mkSqlExprs = allBeamValues (\(Columnar' (QExpr x)) -> x "t")
 
@@ -256,8 +261,8 @@ update (DatabaseEntity (DatabaseTable tblNm tblSettings)) mkAssignments mkWhere 
     assignments = concatMap (\(QAssignment as) -> as) (mkAssignments tblFields)
     QExpr where_ = mkWhere tblFieldExprs
 
-    tblFields = changeBeamRep (\(Columnar' (TableField name)) -> Columnar' (QField tblNm name)) tblSettings
-    tblFieldExprs = changeBeamRep (\(Columnar' (QField _ nm)) -> Columnar' (QExpr (pure (fieldE (unqualifiedField nm))))) tblFields
+    tblFields = changeBeamRep (\(Columnar' (TableField name)) -> Columnar' (QField False tblNm name)) tblSettings
+    tblFieldExprs = changeBeamRep (\(Columnar' (QField _ _ nm)) -> Columnar' (QExpr (pure (fieldE (unqualifiedField nm))))) tblFields
 
 -- | Generate a 'SqlUpdate' that will update the given table with the given value.
 --
@@ -271,6 +276,8 @@ save :: forall table syntax be db.
 
         , SqlValableTable (PrimaryKey table) (Sql92UpdateExpressionSyntax syntax)
         , SqlValableTable table (Sql92UpdateExpressionSyntax syntax)
+
+        , HasTableEquality (Sql92UpdateExpressionSyntax syntax) (PrimaryKey table)
 
         , HasSqlValueSyntax (Sql92ExpressionValueSyntax (Sql92UpdateExpressionSyntax syntax)) Bool
         )

--- a/beam-core/Database/Beam/Query/Internal.hs
+++ b/beam-core/Database/Beam/Query/Internal.hs
@@ -101,7 +101,8 @@ data QNested s
 
 data QField s ty
   = QField
-  { qFieldTblName :: T.Text
+  { qFieldShouldQualify :: Bool
+  , qFieldTblName :: T.Text
   , qFieldName    :: T.Text }
   deriving (Show, Eq, Ord)
 

--- a/beam-core/Database/Beam/Query/Ord.hs
+++ b/beam-core/Database/Beam/Query/Ord.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE UndecidableInstances #-}
+
 -- | Defines classen 'SqlEq' and 'SqlOrd' that can be used to perform equality
 --   and comparison operations on certain expressions.
 --
@@ -22,6 +24,9 @@ module Database.Beam.Query.Ord
   , SqlOrd(..), SqlOrdQuantified(..)
   , QQuantified(..)
 
+  , HasSqlEqualityCheck(..), HasSqlQuantifiedEqualityCheck(..)
+  , HasTableEquality, HasTableEqualityNullable
+
   , anyOf_, anyIn_
   , allOf_, allIn_
 
@@ -35,11 +40,21 @@ import Database.Beam.Query.Operator
 
 import Database.Beam.Schema.Tables
 import Database.Beam.Backend.SQL
+import Database.Beam.Backend.SQL.AST (Expression)
+import Database.Beam.Backend.SQL.Builder (SqlSyntaxBuilder)
 
 import Control.Applicative
 import Control.Monad.State
 
 import Data.Maybe
+import Data.Proxy
+import Data.Kind
+import Data.Word
+import Data.Int
+import Data.Text (Text)
+import Data.Time (UTCTime, LocalTime, Day, TimeOfDay)
+
+import GHC.TypeLits
 
 -- | A data structure representing the set to quantify a comparison operator over.
 data QQuantified expr s r
@@ -138,50 +153,107 @@ infix 4 ==., /=., ==*., /=*.
 infix 4 <., >., <=., >=.
 infix 4 <*., >*., <=*., >=*.
 
+-- | Class for Haskell types that can be compared for equality in the given expression syntax
+class (IsSql92ExpressionSyntax syntax, HasSqlValueSyntax (Sql92ExpressionValueSyntax syntax) Bool) =>
+  HasSqlEqualityCheck syntax a where
+
+  sqlEqE, sqlNeqE :: Proxy a -> syntax -> syntax -> syntax
+  sqlEqE _ = eqE Nothing
+  sqlNeqE _ = neqE Nothing
+
+type family CanCheckMaybeEquality a :: Constraint where
+  CanCheckMaybeEquality (Maybe a) =
+    TypeError ('Text "Attempt to check equality of nested Maybe." ':$$:
+               'Text "Beam can only reasonably check equality of a single nesting of Maybe.")
+  CanCheckMaybeEquality a = ()
+
+instance (HasSqlEqualityCheck syntax a, CanCheckMaybeEquality a) => HasSqlEqualityCheck syntax (Maybe a) where
+  sqlEqE _ = eqMaybeE (Proxy @a)
+  sqlNeqE _ = neqMaybeE (Proxy @a)
+
+instance HasSqlEqualityCheck syntax a => HasSqlEqualityCheck syntax (SqlSerial a) where
+  sqlEqE _ = sqlEqE (Proxy @a)
+  sqlNeqE _ = sqlNeqE (Proxy @a)
+
+-- | Class for Haskell types that can be compared for quantified equality in the given expression syntax
+class HasSqlEqualityCheck syntax a => HasSqlQuantifiedEqualityCheck syntax a where
+  sqlQEqE, sqlQNeqE :: Proxy a -> Maybe (Sql92ExpressionQuantifierSyntax syntax)
+                    -> syntax -> syntax -> syntax
+  sqlQEqE _ = eqE
+  sqlQNeqE _ = neqE
+
+instance HasSqlQuantifiedEqualityCheck syntax a => HasSqlQuantifiedEqualityCheck syntax (SqlSerial a) where
+  sqlQEqE _ = sqlQEqE (Proxy @a)
+  sqlQNeqE _ = sqlQNeqE (Proxy @a)
+
 -- | Compare two arbitrary expressions (of the same type) for equality
-instance IsSql92ExpressionSyntax syntax =>
+instance ( IsSql92ExpressionSyntax syntax, HasSqlEqualityCheck syntax a ) =>
   SqlEq (QGenExpr context syntax s) (QGenExpr context syntax s a) where
 
-  (==.) = qBinOpE (eqE Nothing)
-  (/=.) = qBinOpE (neqE Nothing)
+  (==.) = qBinOpE (sqlEqE (Proxy @a))
+  (/=.) = qBinOpE (sqlNeqE (Proxy @a))
 
 -- | Two arbitrary expressions can be quantifiably compared for equality.
-instance IsSql92ExpressionSyntax syntax =>
+instance ( IsSql92ExpressionSyntax syntax, HasSqlQuantifiedEqualityCheck syntax a ) =>
   SqlEqQuantified (QGenExpr context syntax s) (QQuantified syntax s a) (QGenExpr context syntax s a) where
 
-  a ==*. QQuantified q b = qBinOpE (eqE (Just q)) a (QExpr b)
-  a /=*. QQuantified q b = qBinOpE (neqE (Just q)) a (QExpr b)
+  a ==*. QQuantified q b = qBinOpE (sqlQEqE (Proxy @a) (Just q)) a (QExpr b)
+  a /=*. QQuantified q b = qBinOpE (sqlQNeqE (Proxy @a) (Just q)) a (QExpr b)
+
+-- | Constraint synonym to check if two tables can be compared for equality
+type HasTableEquality expr tbl =
+  (FieldsFulfillConstraint (HasSqlEqualityCheck expr) tbl, Beamable tbl)
+type HasTableEqualityNullable expr tbl =
+  (FieldsFulfillConstraintNullable (HasSqlEqualityCheck expr) tbl, Beamable tbl)
 
 -- | Compare two arbitrary 'Beamable' types containing 'QGenExpr's for equality.
-instance ( IsSql92ExpressionSyntax syntax
+instance ( IsSql92ExpressionSyntax syntax, FieldsFulfillConstraint (HasSqlEqualityCheck syntax) tbl
          , HasSqlValueSyntax (Sql92ExpressionValueSyntax syntax) Bool
          , Beamable tbl ) =>
          SqlEq (QGenExpr context syntax s) (tbl (QGenExpr context syntax s)) where
 
   a ==. b = let (_, e) = runState (zipBeamFieldsM
-                                   (\x'@(Columnar' x) (Columnar' y) ->
+                                   (\x'@(Columnar' (Columnar' (WithConstraint _) :*: Columnar' x)) (Columnar' y) ->
                                        do modify (\expr ->
                                                     case expr of
                                                       Nothing -> Just $ x ==. y
                                                       Just expr' -> Just $ expr' &&. x ==. y)
-                                          return x') a b) Nothing
+                                          return x') (withConstraints @(HasSqlEqualityCheck syntax) `alongsideTable` a) b) Nothing
             in fromMaybe (QExpr (\_ -> valueE (sqlValueSyntax True))) e
   a /=. b = not_ (a ==. b)
 
 instance ( IsSql92ExpressionSyntax syntax
+         , FieldsFulfillConstraintNullable (HasSqlEqualityCheck syntax) tbl
          , HasSqlValueSyntax (Sql92ExpressionValueSyntax syntax) Bool
          , Beamable tbl)
     => SqlEq (QGenExpr context syntax s) (tbl (Nullable (QGenExpr context syntax s))) where
 
   a ==. b = let (_, e) = runState (zipBeamFieldsM
-                                      (\x'@(Columnar' x) (Columnar' y) -> do
+                                      (\x'@(Columnar' (Columnar' (WithConstraint _) :*: Columnar' x)) (Columnar' y) -> do
                                           modify (\expr ->
                                                     case expr of
                                                       Nothing -> Just $ x ==. y
                                                       Just expr' -> Just $ expr' &&. x ==. y)
-                                          return x') a b) Nothing
+                                          return x')
+                                      (withNullableConstraints @(HasSqlEqualityCheck syntax) `alongsideTable` a) b) Nothing
             in fromMaybe (QExpr (\_ -> valueE (sqlValueSyntax True))) e
   a /=. b = not_ (a ==. b)
+
+eqMaybeE, neqMaybeE :: (IsSql92ExpressionSyntax syntax, HasSqlEqualityCheck syntax a) => Proxy a -> syntax -> syntax -> syntax
+eqMaybeE aType a b =
+  let aIsNull = isNullE a
+      bIsNull = isNullE b
+  in caseE [ ( aIsNull `andE` bIsNull, valueE (sqlValueSyntax True) )
+           , ( aIsNull `orE` bIsNull, valueE (sqlValueSyntax False) ) ]
+           (sqlEqE aType a b)
+
+neqMaybeE aType a b =
+  let aIsNull = isNullE a
+      bIsNull = isNullE b
+  in caseE [ ( aIsNull `andE` bIsNull, valueE (sqlValueSyntax False) )
+           , ( aIsNull `orE` bIsNull, valueE (sqlValueSyntax True) ) ]
+           (sqlNeqE aType a b)
+
 
 -- * Comparisons
 
@@ -191,12 +263,12 @@ instance ( IsSql92ExpressionSyntax syntax
 --   Instances are provided to check the ordering of expressions of the same
 --   type. Since there is no universal notion of ordering for an arbitrary
 --   number of expressions, no instance is provided for 'Beamable' types.
-class SqlEq expr e => SqlOrd expr e | e -> expr where
+class SqlOrd expr e | e -> expr where
 
   (<.), (>.), (<=.), (>=.) :: e -> e -> expr Bool
 
 -- | Class for things which can be /quantifiably/ compared.
-class (SqlOrd expr e, SqlEqQuantified expr quantified e) =>
+class SqlOrd expr e =>
   SqlOrdQuantified expr quantified e | e -> expr quantified where
 
   (<*.), (>*.), (<=*.), (>=*.) :: e -> quantified  -> expr Bool
@@ -215,3 +287,83 @@ instance IsSql92ExpressionSyntax syntax =>
   a <=*. QQuantified q b = qBinOpE (leE (Just q)) a (QExpr b)
   a >*. QQuantified q b = qBinOpE (gtE (Just q)) a (QExpr b)
   a >=*. QQuantified q b = qBinOpE (geE (Just q)) a (QExpr b)
+
+instance HasSqlEqualityCheck Expression Text
+instance HasSqlEqualityCheck Expression Integer
+instance HasSqlEqualityCheck Expression Int
+instance HasSqlEqualityCheck Expression Int8
+instance HasSqlEqualityCheck Expression Int16
+instance HasSqlEqualityCheck Expression Int32
+instance HasSqlEqualityCheck Expression Int64
+instance HasSqlEqualityCheck Expression Word
+instance HasSqlEqualityCheck Expression Word8
+instance HasSqlEqualityCheck Expression Word16
+instance HasSqlEqualityCheck Expression Word32
+instance HasSqlEqualityCheck Expression Word64
+instance HasSqlEqualityCheck Expression Double
+instance HasSqlEqualityCheck Expression Float
+instance HasSqlEqualityCheck Expression Bool
+instance HasSqlEqualityCheck Expression UTCTime
+instance HasSqlEqualityCheck Expression LocalTime
+instance HasSqlEqualityCheck Expression Day
+instance HasSqlEqualityCheck Expression TimeOfDay
+
+instance HasSqlQuantifiedEqualityCheck Expression Text
+instance HasSqlQuantifiedEqualityCheck Expression Integer
+instance HasSqlQuantifiedEqualityCheck Expression Int
+instance HasSqlQuantifiedEqualityCheck Expression Int8
+instance HasSqlQuantifiedEqualityCheck Expression Int16
+instance HasSqlQuantifiedEqualityCheck Expression Int32
+instance HasSqlQuantifiedEqualityCheck Expression Int64
+instance HasSqlQuantifiedEqualityCheck Expression Word
+instance HasSqlQuantifiedEqualityCheck Expression Word8
+instance HasSqlQuantifiedEqualityCheck Expression Word16
+instance HasSqlQuantifiedEqualityCheck Expression Word32
+instance HasSqlQuantifiedEqualityCheck Expression Word64
+instance HasSqlQuantifiedEqualityCheck Expression Double
+instance HasSqlQuantifiedEqualityCheck Expression Float
+instance HasSqlQuantifiedEqualityCheck Expression Bool
+instance HasSqlQuantifiedEqualityCheck Expression UTCTime
+instance HasSqlQuantifiedEqualityCheck Expression LocalTime
+instance HasSqlQuantifiedEqualityCheck Expression Day
+instance HasSqlQuantifiedEqualityCheck Expression TimeOfDay
+
+instance HasSqlEqualityCheck SqlSyntaxBuilder Text
+instance HasSqlEqualityCheck SqlSyntaxBuilder Integer
+instance HasSqlEqualityCheck SqlSyntaxBuilder Int
+instance HasSqlEqualityCheck SqlSyntaxBuilder Int8
+instance HasSqlEqualityCheck SqlSyntaxBuilder Int16
+instance HasSqlEqualityCheck SqlSyntaxBuilder Int32
+instance HasSqlEqualityCheck SqlSyntaxBuilder Int64
+instance HasSqlEqualityCheck SqlSyntaxBuilder Word
+instance HasSqlEqualityCheck SqlSyntaxBuilder Word8
+instance HasSqlEqualityCheck SqlSyntaxBuilder Word16
+instance HasSqlEqualityCheck SqlSyntaxBuilder Word32
+instance HasSqlEqualityCheck SqlSyntaxBuilder Word64
+instance HasSqlEqualityCheck SqlSyntaxBuilder Double
+instance HasSqlEqualityCheck SqlSyntaxBuilder Float
+instance HasSqlEqualityCheck SqlSyntaxBuilder Bool
+instance HasSqlEqualityCheck SqlSyntaxBuilder UTCTime
+instance HasSqlEqualityCheck SqlSyntaxBuilder LocalTime
+instance HasSqlEqualityCheck SqlSyntaxBuilder Day
+instance HasSqlEqualityCheck SqlSyntaxBuilder TimeOfDay
+
+instance HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder Text
+instance HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder Integer
+instance HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder Int
+instance HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder Int8
+instance HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder Int16
+instance HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder Int32
+instance HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder Int64
+instance HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder Word
+instance HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder Word8
+instance HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder Word16
+instance HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder Word32
+instance HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder Word64
+instance HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder Double
+instance HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder Float
+instance HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder Bool
+instance HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder UTCTime
+instance HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder LocalTime
+instance HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder Day
+instance HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder TimeOfDay

--- a/beam-core/Database/Beam/Query/Relationships.hs
+++ b/beam-core/Database/Beam/Query/Relationships.hs
@@ -37,7 +37,7 @@ type OneToOne db s one many = OneToMany db s one many
 --   for more information
 type OneToMany db s one many =
   forall syntax.
-  ( IsSql92SelectSyntax syntax
+  ( IsSql92SelectSyntax syntax, HasTableEquality (Sql92SelectExpressionSyntax syntax) (PrimaryKey one)
   , HasSqlValueSyntax (Sql92ExpressionValueSyntax (Sql92SelectExpressionSyntax syntax)) Bool ) =>
   one (QExpr (Sql92SelectExpressionSyntax syntax) s) ->
   Q syntax db s (many (QExpr (Sql92SelectExpressionSyntax syntax) s))
@@ -52,7 +52,7 @@ type OneToMaybe db s tbl rel = OneToManyOptional db s tbl rel
 --   for more information
 type OneToManyOptional db s tbl rel =
   forall syntax.
-  ( IsSql92SelectSyntax syntax
+  ( IsSql92SelectSyntax syntax, HasTableEqualityNullable (Sql92SelectExpressionSyntax syntax) (PrimaryKey tbl)
   , HasSqlValueSyntax (Sql92ExpressionValueSyntax (Sql92SelectExpressionSyntax syntax)) Bool
   , HasSqlValueSyntax (Sql92ExpressionValueSyntax (Sql92SelectExpressionSyntax syntax)) SqlNull ) =>
   tbl (QExpr (Sql92SelectExpressionSyntax syntax) s) ->
@@ -65,6 +65,7 @@ oneToMany_, oneToOne_
   :: ( IsSql92SelectSyntax syntax
      , HasSqlValueSyntax (Sql92ExpressionValueSyntax (Sql92SelectExpressionSyntax syntax)) Bool
      , Database db
+     , HasTableEquality (Sql92SelectExpressionSyntax syntax) (PrimaryKey tbl)
      , Table tbl, Table rel )
   => DatabaseEntity be db (TableEntity rel) {-^ Table to fetch (many) -}
   -> (rel (QExpr (Sql92SelectExpressionSyntax syntax) s) -> PrimaryKey tbl (QExpr (Sql92SelectExpressionSyntax syntax) s))
@@ -82,6 +83,7 @@ oneToManyOptional_, oneToMaybe_
   :: ( IsSql92SelectSyntax syntax
      , HasSqlValueSyntax (Sql92ExpressionValueSyntax (Sql92SelectExpressionSyntax syntax)) Bool
      , HasSqlValueSyntax (Sql92ExpressionValueSyntax (Sql92SelectExpressionSyntax syntax)) SqlNull
+     , HasTableEqualityNullable (Sql92SelectExpressionSyntax syntax) (PrimaryKey tbl)
      , Database db
      , Table tbl, Table rel )
   => DatabaseEntity be db (TableEntity rel) {-^ Table to fetch -}

--- a/beam-core/Database/Beam/Schema/Tables.hs
+++ b/beam-core/Database/Beam/Schema/Tables.hs
@@ -31,6 +31,7 @@ module Database.Beam.Schema.Tables
 
     -- * Columnar and Column Tags
     , Columnar, C, Columnar'(..)
+    , ComposeColumnar(..)
     , Nullable, TableField(..)
     , Exposed
     , fieldName
@@ -41,14 +42,17 @@ module Database.Beam.Schema.Tables
     , FieldsFulfillConstraintNullable
     , WithConstraint(..)
     , TagReducesTo(..), ReplaceBaseTag
+    , withConstrainedFields, withConstraints
+    , withNullableConstrainedFields, withNullableConstraints
 
     -- * Tables
     , Table(..), Beamable(..)
-    , Retaggable(..)
+    , Retaggable(..), (:*:)(..) -- Reexported for use with 'alongsideTable'
     , defTblFieldSettings
     , tableValuesNeeded
     , pk
-    , allBeamValues, changeBeamRep )
+    , allBeamValues, changeBeamRep
+    , alongsideTable )
     where
 
 import           Database.Beam.Backend.Types
@@ -428,6 +432,9 @@ type C f a = Columnar f a
 --   simply wraps 'Columnar f a'
 newtype Columnar' f a = Columnar' (Columnar f a)
 
+-- | Like 'Data.Functor.Compose', but with an intermediate 'Columnar'
+newtype ComposeColumnar f g a = ComposeColumnar (f (Columnar g a))
+
 -- | Metadata for a field of type 'ty' in 'table'.
 --
 --   Essentially a wrapper over the field name, but with a phantom type
@@ -546,6 +553,11 @@ allBeamValues (f :: forall a. Columnar' f a -> b) (tbl :: table f) =
 changeBeamRep :: Beamable table => (forall a. Columnar' f a -> Columnar' g a) -> table f -> table g
 changeBeamRep f tbl = runIdentity (zipBeamFieldsM (\x _ -> return (f x)) tbl tbl)
 
+alongsideTable :: Beamable tbl => tbl f -> tbl g -> tbl (Columnar' f :*: Columnar' g)
+alongsideTable a b =
+  runIdentity $
+  zipBeamFieldsM (\x y -> pure (Columnar' (x :*: y))) a b
+
 class Retaggable f x | x -> f where
   type Retag (tag :: (* -> *) -> * -> *) x :: *
 
@@ -641,6 +653,24 @@ instance FieldsFulfillConstraint c t =>
 instance FieldsFulfillConstraintNullable c t =>
     GFieldsFulfillConstraint c (K1 Generic.R (t (Nullable Exposed))) (K1 Generic.R (t (Nullable Identity))) (K1 Generic.R (t (Nullable (WithConstraint c)))) where
   gWithConstrainedFields _ _ (K1 x) = K1 (to (gWithConstrainedFields (Proxy @c) (Proxy @(Rep (t (Nullable Exposed)))) (from x)))
+
+withConstrainedFields :: forall c tbl
+                       . FieldsFulfillConstraint c tbl => tbl Identity -> tbl (WithConstraint c)
+withConstrainedFields =
+  to . gWithConstrainedFields (Proxy @c) (Proxy @(Rep (tbl Exposed))) . from
+
+withConstraints :: forall c tbl. (Beamable tbl, FieldsFulfillConstraint c tbl) => tbl (WithConstraint c)
+withConstraints =
+  withConstrainedFields (changeBeamRep (\_ -> Columnar' undefined) tblSkeleton)
+
+withNullableConstrainedFields :: forall c tbl
+                               . FieldsFulfillConstraintNullable c tbl => tbl (Nullable Identity) -> tbl (Nullable (WithConstraint c))
+withNullableConstrainedFields =
+  to . gWithConstrainedFields (Proxy @c) (Proxy @(Rep (tbl (Nullable Exposed)))) . from
+
+withNullableConstraints ::  forall c tbl. (Beamable tbl, FieldsFulfillConstraintNullable c tbl) => tbl (Nullable (WithConstraint c))
+withNullableConstraints =
+  withNullableConstrainedFields (changeBeamRep (\_ -> Columnar' undefined) tblSkeleton)
 
 type FieldsFulfillConstraint (c :: * -> Constraint) t =
   ( Generic (t (WithConstraint c)), Generic (t Identity), Generic (t Exposed)

--- a/beam-core/beam-core.cabal
+++ b/beam-core/beam-core.cabal
@@ -2,7 +2,7 @@
 -- see http://haskell.org/cabal/users-guide/
 
 name:                beam-core
-version:             0.6.0.0
+version:             0.7.0.0
 synopsis:            Type-safe, feature-complete SQL query and manipulation interface for Haskell
 description:         Beam is a Haskell library for type-safe querying and manipulation of SQL databases.
                      Beam is modular and supports various backends. In order to use beam, you will need to use

--- a/beam-core/test/Database/Beam/Test/SQL.hs
+++ b/beam-core/test/Database/Beam/Test/SQL.hs
@@ -785,16 +785,22 @@ tableEquality =
 
         Just (FromTable (TableNamed "departments") (Just depts)) <- pure selectFrom
 
-        let andE = ExpressionBinOp "AND"
+        let andE = ExpressionBinOp "AND"; orE = ExpressionBinOp "OR"
             eqE = ExpressionCompOp "==" Nothing
+
+            maybeEqE a b = ExpressionCase [ (andE (ExpressionIsNull a) (ExpressionIsNull b), ExpressionValue (Value True))
+                                          , (orE (ExpressionIsNull a) (ExpressionIsNull b), ExpressionValue (Value False))
+                                          ]
+                                          (eqE a b)
+
             nameCond = eqE (ExpressionFieldName (QualifiedField depts "name"))
                            (ExpressionFieldName (QualifiedField depts "name"))
-            firstNameCond = eqE (ExpressionFieldName (QualifiedField depts "head__first_name"))
+            firstNameCond = maybeEqE (ExpressionFieldName (QualifiedField depts "head__first_name"))
                                 (ExpressionFieldName (QualifiedField depts "head__first_name"))
-            lastNameCond = eqE (ExpressionFieldName (QualifiedField depts "head__last_name"))
-                               (ExpressionFieldName (QualifiedField depts "head__last_name"))
-            createdCond = eqE (ExpressionFieldName (QualifiedField depts "head__created"))
-                              (ExpressionFieldName (QualifiedField depts "head__created"))
+            lastNameCond = maybeEqE (ExpressionFieldName (QualifiedField depts "head__last_name"))
+                                    (ExpressionFieldName (QualifiedField depts "head__last_name"))
+            createdCond = maybeEqE (ExpressionFieldName (QualifiedField depts "head__created"))
+                                   (ExpressionFieldName (QualifiedField depts "head__created"))
         selectWhere @?= andE (andE (andE nameCond firstNameCond) lastNameCond) createdCond
 
    tableExprToTableLiteral =
@@ -809,16 +815,22 @@ tableEquality =
 
         Just (FromTable (TableNamed "departments") (Just depts)) <- pure selectFrom
 
-        let andE = ExpressionBinOp "AND"
+        let andE = ExpressionBinOp "AND"; orE = ExpressionBinOp "OR"
             eqE = ExpressionCompOp "==" Nothing
+
+            maybeEqE a b = ExpressionCase [ (andE (ExpressionIsNull a) (ExpressionIsNull b), ExpressionValue (Value True))
+                                          , (orE (ExpressionIsNull a) (ExpressionIsNull b), ExpressionValue (Value False))
+                                          ]
+                                          (eqE a b)
+
             nameCond = eqE (ExpressionFieldName (QualifiedField depts "name"))
                            (ExpressionValue (Value ("Sales" :: Text)))
-            firstNameCond = eqE (ExpressionFieldName (QualifiedField depts "head__first_name"))
-                                (ExpressionValue (Value ("Jane" :: Text)))
-            lastNameCond = eqE (ExpressionFieldName (QualifiedField depts "head__last_name"))
-                               (ExpressionValue (Value ("Smith" :: Text)))
-            createdCond = eqE (ExpressionFieldName (QualifiedField depts "head__created"))
-                              (ExpressionValue (Value now))
+            firstNameCond = maybeEqE (ExpressionFieldName (QualifiedField depts "head__first_name"))
+                                     (ExpressionValue (Value ("Jane" :: Text)))
+            lastNameCond = maybeEqE (ExpressionFieldName (QualifiedField depts "head__last_name"))
+                                    (ExpressionValue (Value ("Smith" :: Text)))
+            createdCond = maybeEqE (ExpressionFieldName (QualifiedField depts "head__created"))
+                                  (ExpressionValue (Value now))
         selectWhere @?= andE (andE (andE nameCond firstNameCond) lastNameCond) createdCond
 
 -- | Ensure related_ generates the correct ON conditions

--- a/beam-core/test/Database/Beam/Test/SQL.hs
+++ b/beam-core/test/Database/Beam/Test/SQL.hs
@@ -801,7 +801,7 @@ tableEquality =
      testCase "Equality comparison between table expression and table literal" $
      do now <- getCurrentTime
 
-        let exp = DepartmentT "Sales" (EmployeeId (Just "Jane") (Just "Smith") (Just (Auto (Just now))))
+        let exp = DepartmentT "Sales" (EmployeeId (Just "Jane") (Just "Smith") (Just now))
         SqlSelect Select { selectTable = SelectTable { selectWhere = Just selectWhere, selectFrom } } <- pure $ select $ do
           d <- all_ (_departments employeeDbSettings)
           guard_ (d ==. val_ exp)
@@ -1106,7 +1106,7 @@ updateNullable =
   do curTime <- getCurrentTime
 
      let employeeKey :: PrimaryKey EmployeeT (Nullable Identity)
-         employeeKey = EmployeeId (Just "John") (Just "Smith") (Just (Auto (Just curTime)))
+         employeeKey = EmployeeId (Just "John") (Just "Smith") (Just curTime)
 
      SqlUpdate Update { .. } <-
        pure $ update (_departments employeeDbSettings)

--- a/beam-core/test/Database/Beam/Test/Schema.hs
+++ b/beam-core/test/Database/Beam/Test/Schema.hs
@@ -55,18 +55,18 @@ data EmployeeT f
   , _employeeHireDate  :: Columnar f UTCTime
   , _employeeLeaveDate :: Columnar f (Maybe UTCTime)
 
-  , _employeeCreated :: Columnar f (Auto UTCTime)
+  , _employeeCreated :: Columnar f UTCTime
   } deriving Generic
 instance Beamable EmployeeT
 instance Table EmployeeT where
-  data PrimaryKey EmployeeT f = EmployeeId (Columnar f Text) (Columnar f Text) (Columnar f (Auto UTCTime))
+  data PrimaryKey EmployeeT f = EmployeeId (Columnar f Text) (Columnar f Text) (Columnar f UTCTime)
     deriving Generic
   primaryKey e = EmployeeId (_employeeFirstName e) (_employeeLastName e) (_employeeCreated e)
 instance Beamable (PrimaryKey EmployeeT)
 deriving instance Show (TableSettings EmployeeT)
 deriving instance Eq (TableSettings EmployeeT)
-deriving instance (Show (Columnar f Text), Show (Columnar f (Auto UTCTime))) => Show (PrimaryKey EmployeeT f)
-deriving instance (Eq (Columnar f Text), Eq(Columnar f (Auto UTCTime))) => Eq (PrimaryKey EmployeeT f)
+deriving instance (Show (Columnar f Text), Show (Columnar f UTCTime)) => Show (PrimaryKey EmployeeT f)
+deriving instance (Eq (Columnar f Text), Eq (Columnar f  UTCTime)) => Eq (PrimaryKey EmployeeT f)
 
 -- * Verify that the schema is generated properly
 
@@ -116,14 +116,6 @@ deriving instance Eq (TableSettings (PrimaryKey RoleT))
 
 roleTableSchema :: TableSettings RoleT
 roleTableSchema = defTblFieldSettings
-
--- automaticNestedFieldsAreUnset :: TestTree
--- automaticNestedFieldsAreUnset =
---   testCase "Automatic fields are unset when nesting" $
---   do _roleForEmployee roleTableSchema @?=
---        EmployeeId (TableField "for_employee__first_name" (DummyField True False DummyFieldText))
---                   (TableField "for_employee__last_name" (DummyField True False DummyFieldText))
---                   (TableField "for_employee__created" (DummyField True False DummyFieldUTCTime))
 
 -- * Ensure that fields of a nullable primary key are given the proper Maybe type
 

--- a/beam-migrate-cli/beam-migrate-cli.cabal
+++ b/beam-migrate-cli/beam-migrate-cli.cabal
@@ -28,8 +28,8 @@ executable beam-migrate
                        Database.Beam.Migrate.Tool.Log
                        Database.Beam.Migrate.Tool.Migrate
   build-depends:       base                 >=4.9      && <5.0,
-                       beam-core            ==0.6.0.0,
-                       beam-migrate         ==0.2.0.0,
+                       beam-core            >=0.7      && <0.8,
+                       beam-migrate         >=0.3      && <0.4,
                        text                 >=1.2      && <1.3,
                        bytestring           >=0.10     && <0.11,
                        time                 >=1.6      && <1.10,

--- a/beam-migrate/ChangeLog.md
+++ b/beam-migrate/ChangeLog.md
@@ -1,5 +1,3 @@
-# Revision history for beam-migrate
+# 0.3.0.0
 
-## 0.1.0.0  -- YYYY-mm-dd
-
-* First version. Released on an unsuspecting world.
+Version bump due to beam-core change. Got rid of `Auto`

--- a/beam-migrate/Database/Beam/Migrate/Generics/Tables.hs
+++ b/beam-migrate/Database/Beam/Migrate/Generics/Tables.hs
@@ -130,13 +130,6 @@ class IsSql92DataTypeSyntax dataTypeSyntax => HasDefaultSqlDataType dataTypeSynt
                      -> dataTypeSyntax
 
 instance (IsSql92DataTypeSyntax dataTypeSyntax, HasDefaultSqlDataType dataTypeSyntax ty) =>
-  HasDefaultSqlDataType dataTypeSyntax (Auto ty) where
-  defaultSqlDataType _ = defaultSqlDataType (Proxy @ty)
-instance (IsSql92ColumnSchemaSyntax columnSchemaSyntax, HasDefaultSqlDataTypeConstraints columnSchemaSyntax ty) =>
-  HasDefaultSqlDataTypeConstraints columnSchemaSyntax (Auto ty) where
-  defaultSqlDataTypeConstraints _ = defaultSqlDataTypeConstraints (Proxy @ty)
-
-instance (IsSql92DataTypeSyntax dataTypeSyntax, HasDefaultSqlDataType dataTypeSyntax ty) =>
   HasDefaultSqlDataType dataTypeSyntax (Maybe ty) where
   defaultSqlDataType _ = defaultSqlDataType (Proxy @ty)
 instance (IsSql92ColumnSchemaSyntax columnSchemaSyntax, HasDefaultSqlDataTypeConstraints columnSchemaSyntax ty) =>

--- a/beam-migrate/Database/Beam/Migrate/SQL/Tables.hs
+++ b/beam-migrate/Database/Beam/Migrate/SQL/Tables.hs
@@ -31,7 +31,7 @@ module Database.Beam.Migrate.SQL.Tables
   , timestamp, timestamptz
   , binary, varbinary
 
-  , maybeType, autoType
+  , maybeType
 
     -- ** Internal classes
     --    Provided without documentation for use in type signatures
@@ -355,11 +355,6 @@ array (DataType ty) sz = DataType (arrayType ty sz)
 -- a 'DataType' that expects a concrete value to one expecting a 'Maybe'
 maybeType :: DataType syntax a -> DataType syntax (Maybe a)
 maybeType (DataType sqlTy) = DataType sqlTy
-
--- | Wrap a 'DataType' in 'Auto'
-autoType :: DataType syntax a -> DataType syntax (Auto a)
-autoType (DataType sqlTy) = DataType sqlTy
-
 
 -- ** 'field' variable arity classes
 

--- a/beam-migrate/beam-migrate.cabal
+++ b/beam-migrate/beam-migrate.cabal
@@ -1,5 +1,5 @@
 name:                beam-migrate
-version:             0.2.0.0
+version:             0.3.0.0
 synopsis:            SQL DDL support and migrations support library for Beam
 description:         This package provides type classes to allow backends to implement
                      SQL DDL support for beam. This allows you to use beam syntax to
@@ -58,7 +58,7 @@ library
                        Database.Beam.Migrate.Types.Predicates
   -- other-extensions:    
   build-depends:       base                 >=4.9     && <4.11,
-                       beam-core            >=0.6     && <0.7,
+                       beam-core            >=0.7     && <0.8,
                        text                 >=1.2     && <1.3,
                        aeson                >=0.11    && <1.3,
                        bytestring           >=0.10    && <0.11,

--- a/beam-postgres/ChangeLog.md
+++ b/beam-postgres/ChangeLog.md
@@ -1,0 +1,3 @@
+# 0.3.0.0
+
+Initial hackage beam-postgres

--- a/beam-postgres/Database/Beam/Postgres/Connection.hs
+++ b/beam-postgres/Database/Beam/Postgres/Connection.hs
@@ -84,6 +84,8 @@ import           Foreign.C.Types
 
 import           Network.URI (uriToString)
 
+import           System.IO
+
 data PgError
   = PgRowParseError RowReadError
   | PgInternalError String
@@ -347,6 +349,8 @@ withPgDebug dbg conn (Pg action) =
       step (PgRunReturning (PgCommandSyntax PgCommandTypeDataUpdateReturning syntax) mkProcess next) =
         do query <- pgRenderSyntax conn syntax
            dbg (T.unpack (decodeUtf8 query))
+
+           hPutStrLn stderr ("Going to run " ++ show query)
 
            res <- Pg.exec conn query
            sts <- Pg.resultStatus res

--- a/beam-postgres/Database/Beam/Postgres/PgSpecific.hs
+++ b/beam-postgres/Database/Beam/Postgres/PgSpecific.hs
@@ -66,6 +66,12 @@ instance Pg.ToField TsVector where
 
 instance FromBackendRow Postgres TsVector
 
+instance HasSqlEqualityCheck PgExpressionSyntax TsVectorConfig
+instance HasSqlQuantifiedEqualityCheck PgExpressionSyntax TsVectorConfig
+
+instance HasSqlEqualityCheck PgExpressionSyntax TsVector
+instance HasSqlQuantifiedEqualityCheck PgExpressionSyntax TsVector
+
 english :: TsVectorConfig
 english = TsVectorConfig "english"
 
@@ -90,6 +96,9 @@ QExpr vec @@ QExpr q =
 
 newtype TsQuery = TsQuery ByteString
   deriving (Show, Eq, Ord)
+
+instance HasSqlEqualityCheck PgExpressionSyntax TsQuery
+instance HasSqlQuantifiedEqualityCheck PgExpressionSyntax TsQuery
 
 instance Pg.FromField TsQuery where
   fromField field d =
@@ -224,6 +233,9 @@ array_ vs =
 newtype PgJSON a = PgJSON a
   deriving ( Show, Eq, Ord, Hashable, Monoid )
 
+instance HasSqlEqualityCheck PgExpressionSyntax (PgJSON a)
+instance HasSqlQuantifiedEqualityCheck PgExpressionSyntax (PgJSON a)
+
 instance (Typeable x, FromJSON x) => Pg.FromField (PgJSON x) where
   fromField field d =
     if Pg.typeOid field /= Pg.typoid Pg.json
@@ -240,6 +252,9 @@ instance ToJSON a => HasSqlValueSyntax PgValueSyntax (PgJSON a) where
 
 newtype PgJSONB a = PgJSONB a
   deriving ( Show, Eq, Ord, Hashable, Monoid )
+
+instance HasSqlEqualityCheck PgExpressionSyntax (PgJSONB a)
+instance HasSqlQuantifiedEqualityCheck PgExpressionSyntax (PgJSONB a)
 
 instance (Typeable x, FromJSON x) => Pg.FromField (PgJSONB x) where
   fromField field d =
@@ -485,6 +500,9 @@ instance Pg.FromField PgMoney where
    else pure (PgMoney d)
 instance Pg.ToField PgMoney where
   toField (PgMoney a) = Pg.toField a
+
+instance HasSqlEqualityCheck PgExpressionSyntax PgMoney
+instance HasSqlQuantifiedEqualityCheck PgExpressionSyntax PgMoney
 
 instance FromBackendRow Postgres PgMoney
 instance HasSqlValueSyntax PgValueSyntax PgMoney where

--- a/beam-postgres/Database/Beam/Postgres/Types.hs
+++ b/beam-postgres/Database/Beam/Postgres/Types.hs
@@ -37,8 +37,6 @@ data Postgres
 instance BeamBackend Postgres where
   type BackendFromField Postgres = Pg.FromField
 
-instance Pg.FromField x => Pg.FromField (Auto x) where
-  fromField field d = fmap (Auto . Just) (Pg.fromField field d)
 instance Pg.FromField SqlNull where
   fromField field d = fmap (\Pg.Null -> SqlNull) (Pg.fromField field d)
 

--- a/beam-postgres/beam-postgres.cabal
+++ b/beam-postgres/beam-postgres.cabal
@@ -1,7 +1,7 @@
 name:                 beam-postgres
-version:              0.2.0.0
+version:              0.3.0.0
 synopsis:             Connection layer between beam and postgres
-description:          
+description:
 homepage:             http://travis.athougies.net/projects/beam.html
 license:              MIT
 license-file:         LICENSE
@@ -10,6 +10,7 @@ maintainer:           travis@athougies.net
 category:             Database
 build-type:           Simple
 cabal-version:        >=1.18
+extra-doc-files:      ChangeLog.md
 bug-reports:          https://github.com/tathougies/issues
 
 library
@@ -23,8 +24,8 @@ library
                       Database.Beam.Postgres.PgSpecific
                       Database.Beam.Postgres.Extensions
   build-depends:      base                 >=4.7  && <5.0,
-                      beam-core            >=0.6  && <0.7,
-                      beam-migrate         >=0.2  && <0.3,
+                      beam-core            >=0.7  && <0.8,
+                      beam-migrate         >=0.3  && <0.4,
 
                       postgresql-libpq     >=0.8  && <0.10,
                       postgresql-simple    >=0.5  && <0.6,

--- a/beam-postgres/examples/Pagila/Test.hs
+++ b/beam-postgres/examples/Pagila/Test.hs
@@ -20,13 +20,13 @@ import Database.Beam.Migrate.SQL.Types
 
 data SimpleTbl f
   = SimpleTbl
-  { simpletblField1 :: Columnar f (Auto Int)
+  { simpletblField1 :: Columnar f Int
   , simpletblField2 :: Columnar f (Maybe Text) }
   deriving Generic
 instance Beamable SimpleTbl
 
 instance Table SimpleTbl where
-  data PrimaryKey SimpleTbl f = SimpleTblId (Columnar f (Auto Int)) deriving Generic
+  data PrimaryKey SimpleTbl f = SimpleTblId (Columnar f Int) deriving Generic
   primaryKey = SimpleTblId <$> simpletblField1
 instance Beamable (PrimaryKey SimpleTbl)
 

--- a/beam-sqlite/ChangeLog.md
+++ b/beam-sqlite/ChangeLog.md
@@ -1,3 +1,7 @@
+# 0.3.0.0
+
+Bump version due to beam-migrate and beam-core version major version bump
+
 # 0.2.0.0
 
 First split of sqlite backend from main beam package

--- a/beam-sqlite/beam-sqlite.cabal
+++ b/beam-sqlite/beam-sqlite.cabal
@@ -1,5 +1,5 @@
 name:                beam-sqlite
-version:             0.2.0.0
+version:             0.3.0.0
 synopsis:            Beam driver for SQLite
 description:         Beam driver for the <https://sqlite.org/ SQLite> embedded database.
                      See <http://tathougies.github.io/beam/user-guide/backends/beam-sqlite/ here>
@@ -23,8 +23,8 @@ library
                       Database.Beam.Sqlite.Migrate
   build-depends:      base          >=4.7  && <5,
 
-                      beam-core     >=0.6  && <0.7,
-                      beam-migrate  >=0.2  && <0.3,
+                      beam-core     >=0.7  && <0.8,
+                      beam-migrate  >=0.3  && <0.4,
 
                       sqlite-simple >=0.4  && <0.5,
                       text          >=1.0  && <1.3,

--- a/docs/beam-templates/chinook.hs
+++ b/docs/beam-templates/chinook.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 
--- ! BUILD_COMMAND: stack runhaskell --package sqlite-simple --package beam-sqlite --package beam-core -- -fglasgow-exts -XTypeFamilies -XOverloadedStrings -XPartialTypeSignatures -XTypeApplications
+-- ! BUILD_COMMAND: stack runhaskell --package sqlite-simple --package beam-sqlite --package beam-core -- -fglasgow-exts -XTypeFamilies -XOverloadedStrings -XPartialTypeSignatures -XTypeApplications -fno-warn-partial-type-signatures
 -- ! BUILD_DIR: beam-sqlite/examples/
 module Main where
 

--- a/docs/beam-templates/chinookdmlpg.hs
+++ b/docs/beam-templates/chinookdmlpg.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 
--- ! BUILD_COMMAND: stack runhaskell --package postgresql-simple --package beam-postgres --package beam-core -- -fglasgow-exts -XTypeFamilies -XOverloadedStrings -XPartialTypeSignatures -XTypeApplications -i../../beam-sqlite/examples
+-- ! BUILD_COMMAND: stack runhaskell --package postgresql-simple --package beam-postgres --package beam-core -- -fglasgow-exts -XTypeFamilies -XOverloadedStrings -XPartialTypeSignatures -XTypeApplications -i../../beam-sqlite/examples -fno-warn-partial-type-signatures
 -- ! BUILD_DIR: beam-postgres/examples/
 
 module Main where
@@ -10,7 +10,8 @@ import Prelude hiding (lookup)
 
 import Database.Beam
 import Database.Beam.Backend.Types
-import Database.Beam.Postgres
+import Database.Beam.Postgres hiding (insert, runInsert)
+import qualified Database.Beam.Postgres as Pg
 import Database.PostgreSQL.Simple
 
 import Control.Monad

--- a/docs/beam-templates/chinookdmlsqlite.hs
+++ b/docs/beam-templates/chinookdmlsqlite.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 
--- ! BUILD_COMMAND: stack runhaskell --package sqlite-simple --package beam-sqlite --package beam-core -- -fglasgow-exts -XTypeFamilies -XOverloadedStrings -XPartialTypeSignatures -XTypeApplications
+-- ! BUILD_COMMAND: stack runhaskell --package sqlite-simple --package beam-sqlite --package beam-core -- -fglasgow-exts -XTypeFamilies -XOverloadedStrings -XPartialTypeSignatures -XTypeApplications -fno-warn-partial-type-signatures
 -- ! BUILD_DIR: beam-sqlite/examples/
 module Main where
 

--- a/docs/beam-templates/chinookpg.hs
+++ b/docs/beam-templates/chinookpg.hs
@@ -1,14 +1,15 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 
--- ! BUILD_COMMAND: stack runhaskell --package postgresql-simple --package beam-postgres --package beam-core -- -fglasgow-exts -XTypeFamilies -XOverloadedStrings -XPartialTypeSignatures -XTypeApplications -i../../beam-sqlite/examples
+-- ! BUILD_COMMAND: stack runhaskell --package postgresql-simple --package beam-postgres --package beam-core -- -fglasgow-exts -XTypeFamilies -XOverloadedStrings -XPartialTypeSignatures -XTypeApplications -i../../beam-sqlite/examples -fno-warn-partial-type-signatures
 -- ! BUILD_DIR: beam-postgres/examples/
 
 module Main where
 
 import Database.Beam
 import Database.Beam.Backend.Types
-import Database.Beam.Postgres
+import Database.Beam.Postgres hiding (insert, runInsert)
+import qualified Database.Beam.Postgres as Pg
 import Database.PostgreSQL.Simple
 
 import Control.Monad

--- a/docs/beam-templates/employee1out-agg.hs
+++ b/docs/beam-templates/employee1out-agg.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 
--- ! BUILD_COMMAND: stack runhaskell --package sqlite-simple --package beam-sqlite --package beam-core -- -fglasgow-exts -XStandaloneDeriving -XTypeSynonymInstances -XDeriveGeneric -XGADTs -XOverloadedStrings -XFlexibleContexts -XFlexibleInstances -XTypeFamilies -XTypeApplications -XAllowAmbiguousTypes -XPartialTypeSignatures
+-- ! BUILD_COMMAND: stack runhaskell --package sqlite-simple --package beam-sqlite --package beam-core -- -fglasgow-exts -XStandaloneDeriving -XTypeSynonymInstances -XDeriveGeneric -XGADTs -XOverloadedStrings -XFlexibleContexts -XFlexibleInstances -XTypeFamilies -XTypeApplications -XAllowAmbiguousTypes -XPartialTypeSignatures -fno-warn-partial-type-signatures
 -- ! BUILD_DIR: beam-sqlite/examples/
 module Main where
 
@@ -39,7 +39,7 @@ data ShoppingCartDb f = ShoppingCartDb
 
 instance Database ShoppingCartDb
 
-shoppingCartDb :: DatabaseSettings be ShoppingCartDb
+shoppingCartDb :: DatabaseSettings Sqlite ShoppingCartDb
 shoppingCartDb = defaultDbSettings
 
 main :: IO ()

--- a/docs/beam-templates/employee1out.hs
+++ b/docs/beam-templates/employee1out.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 
--- ! BUILD_COMMAND: stack runhaskell --package sqlite-simple --package beam-sqlite --package beam-core -- -fglasgow-exts -XStandaloneDeriving -XTypeSynonymInstances -XDeriveGeneric -XGADTs -XOverloadedStrings -XFlexibleContexts -XFlexibleInstances -XTypeFamilies -XTypeApplications -XAllowAmbiguousTypes -XPartialTypeSignatures
+-- ! BUILD_COMMAND: stack runhaskell --package sqlite-simple --package beam-sqlite --package beam-core -- -fglasgow-exts -XStandaloneDeriving -XTypeSynonymInstances -XDeriveGeneric -XGADTs -XOverloadedStrings -XFlexibleContexts -XFlexibleInstances -XTypeFamilies -XTypeApplications -XAllowAmbiguousTypes -XPartialTypeSignatures -fno-warn-partial-type-signatures
 -- ! BUILD_DIR: beam-sqlite/examples/
 module Main where
 
@@ -39,7 +39,7 @@ data ShoppingCartDb f = ShoppingCartDb
 
 instance Database ShoppingCartDb
 
-shoppingCartDb :: DatabaseSettings be ShoppingCartDb
+shoppingCartDb :: DatabaseSettings Sqlite ShoppingCartDb
 shoppingCartDb = defaultDbSettings
 
 main :: IO ()

--- a/docs/beam-templates/employee1sql-agg.hs
+++ b/docs/beam-templates/employee1sql-agg.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 
--- ! BUILD_COMMAND: stack runhaskell --package sqlite-simple --package beam-sqlite --package beam-core -- -fglasgow-exts -XStandaloneDeriving -XTypeSynonymInstances -XDeriveGeneric -XGADTs -XOverloadedStrings -XFlexibleContexts -XFlexibleInstances -XTypeFamilies -XTypeApplications -XAllowAmbiguousTypes -XPartialTypeSignatures
+-- ! BUILD_COMMAND: stack runhaskell --package sqlite-simple --package beam-sqlite --package beam-core -- -fglasgow-exts -XStandaloneDeriving -XTypeSynonymInstances -XDeriveGeneric -XGADTs -XOverloadedStrings -XFlexibleContexts -XFlexibleInstances -XTypeFamilies -XTypeApplications -XAllowAmbiguousTypes -XPartialTypeSignatures -fno-warn-partial-type-signatures 
 -- ! BUILD_DIR: beam-sqlite/examples/
 module Main where
 
@@ -38,7 +38,7 @@ data ShoppingCartDb f = ShoppingCartDb
 
 instance Database ShoppingCartDb
 
-shoppingCartDb :: DatabaseSettings be ShoppingCartDb
+shoppingCartDb :: DatabaseSettings Sqlite ShoppingCartDb
 shoppingCartDb = defaultDbSettings
 
 main :: IO ()

--- a/docs/beam-templates/employee1sql.hs
+++ b/docs/beam-templates/employee1sql.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 
--- ! BUILD_COMMAND: stack runhaskell --package sqlite-simple --package beam-sqlite --package beam-core -- -fglasgow-exts -XStandaloneDeriving -XTypeSynonymInstances -XDeriveGeneric -XGADTs -XOverloadedStrings -XFlexibleContexts -XFlexibleInstances -XTypeFamilies -XTypeApplications -XAllowAmbiguousTypes -XPartialTypeSignatures
+-- ! BUILD_COMMAND: stack runhaskell --package sqlite-simple --package beam-sqlite --package beam-core -- -fglasgow-exts -XStandaloneDeriving -XTypeSynonymInstances -XDeriveGeneric -XGADTs -XOverloadedStrings -XFlexibleContexts -XFlexibleInstances -XTypeFamilies -XTypeApplications -XAllowAmbiguousTypes -XPartialTypeSignatures -fno-warn-partial-type-signatures
 -- ! BUILD_DIR: beam-sqlite/examples/
 module Main where
 
@@ -38,7 +38,7 @@ data ShoppingCartDb f = ShoppingCartDb
 
 instance Database ShoppingCartDb
 
-shoppingCartDb :: DatabaseSettings be ShoppingCartDb
+shoppingCartDb :: DatabaseSettings Sqlite ShoppingCartDb
 shoppingCartDb = defaultDbSettings
 
 main :: IO ()

--- a/docs/beam-templates/employee2out.hs
+++ b/docs/beam-templates/employee2out.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 
--- ! BUILD_COMMAND: stack runhaskell --package sqlite-simple --package beam-sqlite --package beam-core --package microlens -- -fglasgow-exts -XStandaloneDeriving -XTypeSynonymInstances -XDeriveGeneric -XGADTs -XOverloadedStrings -XFlexibleContexts -XFlexibleInstances -XTypeFamilies -XTypeApplications -XAllowAmbiguousTypes -XPartialTypeSignatures
+-- ! BUILD_COMMAND: stack runhaskell --package sqlite-simple --package beam-sqlite --package beam-core --package microlens -- -fglasgow-exts -XStandaloneDeriving -XTypeSynonymInstances -XDeriveGeneric -XGADTs -XOverloadedStrings -XFlexibleContexts -XFlexibleInstances -XTypeFamilies -XTypeApplications -XAllowAmbiguousTypes -XPartialTypeSignatures -fno-warn-partial-type-signatures
 -- ! BUILD_DIR: beam-sqlite/examples/
 module Main where
 
@@ -40,7 +40,7 @@ instance Table UserT where
 instance Beamable (PrimaryKey UserT)
 
 data AddressT f = Address
-                { _addressId    :: C f (Auto Int)
+                { _addressId    :: C f Int
                 , _addressLine1 :: C f Text
                 , _addressLine2 :: C f (Maybe Text)
                 , _addressCity  :: C f Text
@@ -54,7 +54,7 @@ deriving instance Show (PrimaryKey UserT Identity)
 deriving instance Show Address
 
 instance Table AddressT where
-    data PrimaryKey AddressT f = AddressId (Columnar f (Auto Int)) deriving Generic
+    data PrimaryKey AddressT f = AddressId (Columnar f Int) deriving Generic
     primaryKey = AddressId . _addressId
 
 instance Beamable AddressT
@@ -67,7 +67,7 @@ data ShoppingCartDb f = ShoppingCartDb
 
 instance Database ShoppingCartDb
 
-shoppingCartDb :: DatabaseSettings be ShoppingCartDb
+shoppingCartDb :: DatabaseSettings Sqlite ShoppingCartDb
 shoppingCartDb = defaultDbSettings `withDbModification`
                  dbModification {
                    _shoppingCartUserAddresses =
@@ -78,7 +78,7 @@ shoppingCartDb = defaultDbSettings `withDbModification`
                      }
                  }
 
-shoppingCartDb1 :: DatabaseSettings be ShoppingCartDb
+shoppingCartDb1 :: DatabaseSettings Sqlite ShoppingCartDb
 shoppingCartDb1 = defaultDbSettings `withDbModification`
                   dbModification {
                     _shoppingCartUsers = modifyTable (\_ -> "users") tableModification,
@@ -88,7 +88,7 @@ shoppingCartDb1 = defaultDbSettings `withDbModification`
 Address (LensFor addressId)    (LensFor addressLine1)
         (LensFor addressLine2) (LensFor addressCity)
         (LensFor addressState) (LensFor addressZip)
-        (UserId (LensFor addressForUserId)) = 
+        (UserId (LensFor addressForUserId)) =
         tableLenses
 
 User (LensFor userEmail)    (LensFor userFirstName)
@@ -122,12 +122,12 @@ main =
          print :: Show a => a -> IO ()
          print = putStrLn . show
 
-     let addresses = [ Address (Auto Nothing) "123 Little Street" Nothing "Boston" "MA" "12345" (pk james)
-                     , Address (Auto Nothing) "222 Main Street" (Just "Ste 1") "Houston" "TX" "8888" (pk betty)
-                     , Address (Auto Nothing) "9999 Residence Ave" Nothing "Sugarland" "TX" "8989" (pk betty) ]
+     let addresses = [ Address default_ (val_ "123 Little Street") (val_ Nothing) (val_ "Boston") (val_ "MA") (val_ "12345") (pk james)
+                     , Address default_ (val_ "222 Main Street") (val_ (Just "Ste 1")) (val_ "Houston") (val_ "TX") (val_ "8888") (pk betty)
+                     , Address default_ (val_ "9999 Residence Ave") (val_ Nothing) (val_ "Sugarland") (val_ "TX") (val_ "8989") (pk betty) ]
 
      withDatabase conn $ runInsert $
       insert (_shoppingCartUserAddresses shoppingCartDb) $
-      insertValues addresses
+      insertExpressions addresses
 
      BEAM_PLACEHOLDER

--- a/docs/beam-templates/employee2sql.hs
+++ b/docs/beam-templates/employee2sql.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 
--- ! BUILD_COMMAND: stack runhaskell --package sqlite-simple --package beam-sqlite --package beam-core --package microlens -- -fglasgow-exts -XStandaloneDeriving -XTypeSynonymInstances -XDeriveGeneric -XGADTs -XOverloadedStrings -XFlexibleContexts -XFlexibleInstances -XTypeFamilies -XTypeApplications -XAllowAmbiguousTypes -XPartialTypeSignatures
+-- ! BUILD_COMMAND: stack runhaskell --package sqlite-simple --package beam-sqlite --package beam-core --package microlens -- -fglasgow-exts -XStandaloneDeriving -XTypeSynonymInstances -XDeriveGeneric -XGADTs -XOverloadedStrings -XFlexibleContexts -XFlexibleInstances -XTypeFamilies -XTypeApplications -XAllowAmbiguousTypes -XPartialTypeSignatures -fno-warn-partial-type-signatures
 -- ! BUILD_DIR: beam-sqlite/examples/
 module Main where
 
@@ -40,7 +40,7 @@ instance Beamable (PrimaryKey UserT)
 type UserId = PrimaryKey UserT Identity
 
 data AddressT f = Address
-                { _addressId    :: C f (Auto Int)
+                { _addressId    :: C f Int
                 , _addressLine1 :: C f Text
                 , _addressLine2 :: C f (Maybe Text)
                 , _addressCity  :: C f Text
@@ -54,7 +54,7 @@ deriving instance Show (PrimaryKey UserT Identity)
 deriving instance Show Address
 
 instance Table AddressT where
-    data PrimaryKey AddressT f = AddressId (Columnar f (Auto Int)) deriving Generic
+    data PrimaryKey AddressT f = AddressId (Columnar f Int) deriving Generic
     primaryKey = AddressId . _addressId
 
 instance Beamable AddressT
@@ -67,7 +67,7 @@ data ShoppingCartDb f = ShoppingCartDb
 
 instance Database ShoppingCartDb
 
-shoppingCartDb :: DatabaseSettings be ShoppingCartDb
+shoppingCartDb :: DatabaseSettings Sqlite ShoppingCartDb
 shoppingCartDb = defaultDbSettings `withDbModification`
                  dbModification {
                    _shoppingCartUserAddresses =
@@ -78,7 +78,7 @@ shoppingCartDb = defaultDbSettings `withDbModification`
                      }
                  }
 
-shoppingCartDb1 :: DatabaseSettings be ShoppingCartDb
+shoppingCartDb1 :: DatabaseSettings Sqlite ShoppingCartDb
 shoppingCartDb1 = defaultDbSettings `withDbModification`
                   dbModification {
                     _shoppingCartUsers = modifyTable (\_ -> "users") tableModification,
@@ -88,7 +88,7 @@ shoppingCartDb1 = defaultDbSettings `withDbModification`
 Address (LensFor addressId)    (LensFor addressLine1)
         (LensFor addressLine2) (LensFor addressCity)
         (LensFor addressState) (LensFor addressZip)
-        (UserId (LensFor addressForUserId)) = 
+        (UserId (LensFor addressForUserId)) =
         tableLenses
 
 User (LensFor userEmail)    (LensFor userFirstName)
@@ -121,13 +121,13 @@ main =
          print :: a -> IO ()
          print _ = pure ()
 
-     let addresses = [ Address (Auto Nothing) "123 Little Street" Nothing "Boston" "MA" "12345" (pk james)
-                     , Address (Auto Nothing) "222 Main Street" (Just "Ste 1") "Houston" "TX" "8888" (pk betty)
-                     , Address (Auto Nothing) "9999 Residence Ave" Nothing "Sugarland" "TX" "8989" (pk betty) ]
+     let addresses = [ Address default_ (val_ "123 Little Street") (val_ Nothing) (val_ "Boston") (val_ "MA") (val_ "12345") (pk james)
+                     , Address default_ (val_ "222 Main Street") (val_ (Just "Ste 1")) (val_ "Houston") (val_ "TX") (val_ "8888") (pk betty)
+                     , Address default_ (val_ "9999 Residence Ave") (val_ Nothing) (val_ "Sugarland") (val_ "TX") (val_ "8989") (pk betty) ]
 
      withDatabase conn $ runInsert $
        insert (_shoppingCartUserAddresses shoppingCartDb) $
-       insertValues addresses
+       insertExpressions addresses
 
      BEAM_PLACEHOLDER
 

--- a/docs/beam-templates/employee3common.hs
+++ b/docs/beam-templates/employee3common.hs
@@ -40,7 +40,7 @@ instance Table UserT where
 instance Beamable (PrimaryKey UserT)
 
 data AddressT f = Address
-                { _addressId    :: C f (Auto Int)
+                { _addressId    :: C f Int
                 , _addressLine1 :: C f Text
                 , _addressLine2 :: C f (Maybe Text)
                 , _addressCity  :: C f Text
@@ -54,15 +54,15 @@ deriving instance Show (PrimaryKey UserT Identity)
 deriving instance Show Address
 
 instance Table AddressT where
-    data PrimaryKey AddressT f = AddressId (Columnar f (Auto Int)) deriving Generic
+    data PrimaryKey AddressT f = AddressId (Columnar f Int) deriving Generic
     primaryKey = AddressId . _addressId
-type AddressId = PrimaryKey AddressT Identity -- For convenience    
+type AddressId = PrimaryKey AddressT Identity -- For convenience
 
 instance Beamable AddressT
 instance Beamable (PrimaryKey AddressT)
 
 data ProductT f = Product
-                { _productId          :: C f (Auto Int)
+                { _productId          :: C f Int
                 , _productTitle       :: C f Text
                 , _productDescription :: C f Text
                 , _productPrice       :: C f Int {- Price in cents -} }
@@ -71,7 +71,7 @@ type Product = ProductT Identity
 deriving instance Show Product
 
 instance Table ProductT where
-  data PrimaryKey ProductT f = ProductId (Columnar f (Auto Int))
+  data PrimaryKey ProductT f = ProductId (Columnar f Int)
                                deriving Generic
   primaryKey = ProductId . _productId
 
@@ -80,7 +80,7 @@ instance Beamable (PrimaryKey ProductT)
 deriving instance Show (PrimaryKey AddressT Identity)
 
 data OrderT f = Order
-              { _orderId      :: Columnar f (Auto Int)
+              { _orderId      :: Columnar f Int
               , _orderDate    :: Columnar f LocalTime
               , _orderForUser :: PrimaryKey UserT f
               , _orderShipToAddress :: PrimaryKey AddressT f
@@ -90,7 +90,7 @@ type Order = OrderT Identity
 deriving instance Show Order
 
 instance Table OrderT where
-    data PrimaryKey OrderT f = OrderId (Columnar f (Auto Int))
+    data PrimaryKey OrderT f = OrderId (Columnar f Int)
                                deriving Generic
     primaryKey = OrderId . _orderId
 
@@ -110,7 +110,7 @@ instance FromField ShippingCarrier where
 instance (BeamBackend be, BackendFromField be ShippingCarrier) => FromBackendRow be ShippingCarrier
 
 data ShippingInfoT f = ShippingInfo
-                     { _shippingInfoId             :: Columnar f (Auto Int)
+                     { _shippingInfoId             :: Columnar f Int
                      , _shippingInfoCarrier        :: Columnar f ShippingCarrier
                      , _shippingInfoTrackingNumber :: Columnar f Text }
                        deriving Generic
@@ -118,7 +118,7 @@ type ShippingInfo = ShippingInfoT Identity
 deriving instance Show ShippingInfo
 
 instance Table ShippingInfoT where
-    data PrimaryKey ShippingInfoT f = ShippingInfoId (Columnar f (Auto Int))
+    data PrimaryKey ShippingInfoT f = ShippingInfoId (Columnar f Int)
                                       deriving Generic
     primaryKey = ShippingInfoId . _shippingInfoId
 
@@ -212,15 +212,15 @@ main =
            [ User "james@example.com" "James" "Smith"  "b4cc344d25a2efe540adbf2678e2304c" {- james -}
            , User "betty@example.com" "Betty" "Jones"  "82b054bd83ffad9b6cf8bdb98ce3cc2f" {- betty -}
            , User "sam@example.com"   "Sam"   "Taylor" "332532dcfaa1cbf61e2a266bd723612c" {- sam -} ]
-         addresses = [ Address (Auto Nothing) "123 Little Street" Nothing "Boston" "MA" "12345" (pk james)
 
-                     , Address (Auto Nothing) "222 Main Street" (Just "Ste 1") "Houston" "TX" "8888" (pk betty)
-                     , Address (Auto Nothing) "9999 Residence Ave" Nothing "Sugarland" "TX" "8989" (pk betty) ]
+         addresses = [ Address default_ (val_ "123 Little Street") (val_ Nothing) (val_ "Boston") (val_ "MA") (val_ "12345") (pk james)
+                     , Address default_ (val_ "222 Main Street") (val_ (Just "Ste 1")) (val_ "Houston") (val_ "TX") (val_ "8888") (pk betty)
+                     , Address default_ (val_ "9999 Residence Ave") (val_ Nothing) (val_ "Sugarland") (val_ "TX") (val_ "8989") (pk betty) ]
 
-         products = [ Product (Auto Nothing) "Red Ball" "A bright red, very spherical ball" 1000
-                    , Product (Auto Nothing) "Math Textbook" "Contains a lot of important math theorems and formulae" 2500
-                    , Product (Auto Nothing) "Intro to Haskell" "Learn the best programming language in the world" 3000
-                    , Product (Auto Nothing) "Suitcase" "A hard durable suitcase" 15000 ]
+         products = [ Product default_ (val_ "Red Ball") (val_ "A bright red, very spherical ball") (val_ 1000)
+                    , Product default_ (val_ "Math Textbook") (val_ "Contains a lot of important math theorems and formulae") (val_ 2500)
+                    , Product default_ (val_ "Intro to Haskell") (val_ "Learn the best programming language in the world") (val_ 3000)
+                    , Product default_ (val_ "Suitcase") (val_ "A hard durable suitcase") (val_ 15000) ]
 
      (jamesAddress1, bettyAddress1, bettyAddress2, redBall, mathTextbook, introToHaskell, suitcase) <-
        withDatabase conn $ do
@@ -229,11 +229,11 @@ main =
 
          [jamesAddress1, bettyAddress1, bettyAddress2] <-
            runInsertReturningList $
-           insertReturning (shoppingCartDb ^. shoppingCartUserAddresses) $ insertValues addresses
+           insertReturning (shoppingCartDb ^. shoppingCartUserAddresses) $ insertExpressions addresses
 
          [redBall, mathTextbook, introToHaskell, suitcase] <-
            runInsertReturningList $
-           insertReturning (shoppingCartDb ^. shoppingCartProducts) $ insertValues products
+           insertReturning (shoppingCartDb ^. shoppingCartProducts) $ insertExpressions products
 
          pure ( jamesAddress1, bettyAddress1, bettyAddress2, redBall, mathTextbook, introToHaskell, suitcase )
 
@@ -242,5 +242,5 @@ main =
          [bettyShippingInfo] <-
            runInsertReturningList $
            insertReturning (shoppingCartDb ^. shoppingCartShippingInfos) $
-           insertValues [ ShippingInfo (Auto Nothing) USPS "12345790ABCDEFGHI" ]
+           insertExpressions [ ShippingInfo default_ (val_ USPS) (val_ "12345790ABCDEFGHI") ]
          pure bettyShippingInfo

--- a/docs/beam-templates/employee3out-1.hs
+++ b/docs/beam-templates/employee3out-1.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE CPP #-}
 
--- ! BUILD_COMMAND: stack runhaskell --package sqlite-simple --package beam-sqlite --package beam-core --package microlens -- -fglasgow-exts -XStandaloneDeriving -XTypeSynonymInstances -XDeriveGeneric -XGADTs -XOverloadedStrings -XFlexibleContexts -XFlexibleInstances -XTypeFamilies -XTypeApplications -XAllowAmbiguousTypes -XPartialTypeSignatures -I../../docs/beam-templates
+-- ! BUILD_COMMAND: stack runhaskell --package sqlite-simple --package beam-sqlite --package beam-core --package microlens -- -fglasgow-exts -XStandaloneDeriving -XTypeSynonymInstances -XDeriveGeneric -XGADTs -XOverloadedStrings -XFlexibleContexts -XFlexibleInstances -XTypeFamilies -XTypeApplications -XAllowAmbiguousTypes -XPartialTypeSignatures -I../../docs/beam-templates -fno-warn-partial-type-signatures
 -- ! BUILD_DIR: beam-sqlite/examples/
 -- ! EXTRA_DEPS: employee3common.hs employee3commonout.hs
 module Main where
@@ -15,9 +15,9 @@ module Main where
          runInsertReturningList $
            insertReturning (shoppingCartDb ^. shoppingCartOrders) $
            insertExpressions $
-           [ Order (val_ (Auto Nothing)) currentTimestamp_ (val_ (pk james)) (val_ (pk jamesAddress1)) nothing_
-           , Order (val_ (Auto Nothing)) currentTimestamp_ (val_ (pk betty)) (val_ (pk bettyAddress1)) (just_ (val_ (pk bettyShippingInfo)))
-           , Order (val_ (Auto Nothing)) currentTimestamp_ (val_ (pk james)) (val_ (pk jamesAddress1)) nothing_ ]
+           [ Order default_ currentTimestamp_ (val_ (pk james)) (val_ (pk jamesAddress1)) nothing_
+           , Order default_ currentTimestamp_ (val_ (pk betty)) (val_ (pk bettyAddress1)) (just_ (val_ (pk bettyShippingInfo)))
+           , Order default_ currentTimestamp_ (val_ (pk james)) (val_ (pk jamesAddress1)) nothing_ ]
 
 #include "employee3commonout.hs"
 

--- a/docs/beam-templates/employee3out-2.hs
+++ b/docs/beam-templates/employee3out-2.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE CPP #-}
 
--- ! BUILD_COMMAND: stack runhaskell --package sqlite-simple --package beam-sqlite --package beam-core --package microlens -- -fglasgow-exts -XStandaloneDeriving -XTypeSynonymInstances -XDeriveGeneric -XGADTs -XOverloadedStrings -XFlexibleContexts -XFlexibleInstances -XTypeFamilies -XTypeApplications -XAllowAmbiguousTypes -XPartialTypeSignatures -I../../docs/beam-templates
+-- ! BUILD_COMMAND: stack runhaskell --package sqlite-simple --package beam-sqlite --package beam-core --package microlens -- -fglasgow-exts -XStandaloneDeriving -XTypeSynonymInstances -XDeriveGeneric -XGADTs -XOverloadedStrings -XFlexibleContexts -XFlexibleInstances -XTypeFamilies -XTypeApplications -XAllowAmbiguousTypes -XPartialTypeSignatures -I../../docs/beam-templates -fno-warn-partial-type-signatures
 -- ! BUILD_DIR: beam-sqlite/examples/
 -- ! EXTRA_DEPS: employee3common.hs employee3commonout.hs
 module Main where
@@ -15,9 +15,9 @@ module Main where
          runInsertReturningList $
            insertReturning (shoppingCartDb ^. shoppingCartOrders) $
            insertExpressions $
-           [ Order (val_ (Auto Nothing)) currentTimestamp_ (val_ (pk james)) (val_ (pk jamesAddress1)) nothing_
-           , Order (val_ (Auto Nothing)) currentTimestamp_ (val_ (pk betty)) (val_ (pk bettyAddress1)) (just_ (val_ (pk bettyShippingInfo)))
-           , Order (val_ (Auto Nothing)) currentTimestamp_ (val_ (pk james)) (val_ (pk jamesAddress1)) nothing_ ]
+           [ Order default_ currentTimestamp_ (val_ (pk james)) (val_ (pk jamesAddress1)) nothing_
+           , Order default_ currentTimestamp_ (val_ (pk betty)) (val_ (pk bettyAddress1)) (just_ (val_ (pk bettyShippingInfo)))
+           , Order default_ currentTimestamp_ (val_ (pk james)) (val_ (pk jamesAddress1)) nothing_ ]
 
      let lineItems = [ LineItem (pk jamesOrder1) (pk redBall) 10
                      , LineItem (pk jamesOrder1) (pk mathTextbook) 1

--- a/docs/beam-templates/employee3out.hs
+++ b/docs/beam-templates/employee3out.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE CPP #-}
 
--- ! BUILD_COMMAND: stack runhaskell --package sqlite-simple --package beam-sqlite --package beam-core --package microlens -- -fglasgow-exts -XStandaloneDeriving -XTypeSynonymInstances -XDeriveGeneric -XGADTs -XOverloadedStrings -XFlexibleContexts -XFlexibleInstances -XTypeFamilies -XTypeApplications -XAllowAmbiguousTypes -XPartialTypeSignatures -I../../docs/beam-templates
+-- ! BUILD_COMMAND: stack runhaskell --package sqlite-simple --package beam-sqlite --package beam-core --package microlens -- -fglasgow-exts -XStandaloneDeriving -XTypeSynonymInstances -XDeriveGeneric -XGADTs -XOverloadedStrings -XFlexibleContexts -XFlexibleInstances -XTypeFamilies -XTypeApplications -XAllowAmbiguousTypes -XPartialTypeSignatures -I../../docs/beam-templates -fno-warn-partial-type-signatures
 -- ! BUILD_DIR: beam-sqlite/examples/
 -- ! EXTRA_DEPS: employee3common.hs employee3commonout.hs
 module Main where

--- a/docs/beam-templates/employee3sql-1.hs
+++ b/docs/beam-templates/employee3sql-1.hs
@@ -15,9 +15,9 @@ module Main where
          runInsertReturningList $
            insertReturning (shoppingCartDb ^. shoppingCartOrders) $
            insertExpressions $
-           [ Order (val_ (Auto Nothing)) currentTimestamp_ (val_ (pk james)) (val_ (pk jamesAddress1)) nothing_
-           , Order (val_ (Auto Nothing)) currentTimestamp_ (val_ (pk betty)) (val_ (pk bettyAddress1)) (just_ (val_ (pk bettyShippingInfo)))
-           , Order (val_ (Auto Nothing)) currentTimestamp_ (val_ (pk james)) (val_ (pk jamesAddress1)) nothing_ ]
+           [ Order default_ currentTimestamp_ (val_ (pk james)) (val_ (pk jamesAddress1)) nothing_
+           , Order default_ currentTimestamp_ (val_ (pk betty)) (val_ (pk bettyAddress1)) (just_ (val_ (pk bettyShippingInfo)))
+           , Order default_ currentTimestamp_ (val_ (pk james)) (val_ (pk jamesAddress1)) nothing_ ]
 #include "employee3commonsql.hs"
 
      BEAM_PLACEHOLDER

--- a/docs/beam-templates/employee3sql-2.hs
+++ b/docs/beam-templates/employee3sql-2.hs
@@ -15,9 +15,9 @@ module Main where
          runInsertReturningList $
            insertReturning (shoppingCartDb ^. shoppingCartOrders) $
            insertExpressions $
-           [ Order (val_ (Auto Nothing)) currentTimestamp_ (val_ (pk james)) (val_ (pk jamesAddress1)) nothing_
-           , Order (val_ (Auto Nothing)) currentTimestamp_ (val_ (pk betty)) (val_ (pk bettyAddress1)) (just_ (val_ (pk bettyShippingInfo)))
-           , Order (val_ (Auto Nothing)) currentTimestamp_ (val_ (pk james)) (val_ (pk jamesAddress1)) nothing_ ]
+           [ Order default_ currentTimestamp_ (val_ (pk james)) (val_ (pk jamesAddress1)) nothing_
+           , Order default_ currentTimestamp_ (val_ (pk betty)) (val_ (pk bettyAddress1)) (just_ (val_ (pk bettyShippingInfo)))
+           , Order default_ currentTimestamp_ (val_ (pk james)) (val_ (pk jamesAddress1)) nothing_ ]
 
      let lineItems = [ LineItem (pk jamesOrder1) (pk redBall) 10
                      , LineItem (pk jamesOrder1) (pk mathTextbook) 1

--- a/docs/beam-templates/employee3sql.hs
+++ b/docs/beam-templates/employee3sql.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE CPP #-}
 
--- ! BUILD_COMMAND: stack runhaskell --package sqlite-simple --package beam-sqlite --package beam-core --package microlens -- -fglasgow-exts -XStandaloneDeriving -XTypeSynonymInstances -XDeriveGeneric -XGADTs -XOverloadedStrings -XFlexibleContexts -XFlexibleInstances -XTypeFamilies -XTypeApplications -XAllowAmbiguousTypes -XPartialTypeSignatures  -I../../docs/beam-templates
+-- ! BUILD_COMMAND: stack runhaskell --package sqlite-simple --package beam-sqlite --package beam-core --package microlens -- -fglasgow-exts -XStandaloneDeriving -XTypeSynonymInstances -XDeriveGeneric -XGADTs -XOverloadedStrings -XFlexibleContexts -XFlexibleInstances -XTypeFamilies -XTypeApplications -XAllowAmbiguousTypes -XPartialTypeSignatures  -I../../docs/beam-templates -fno-warn-partial-type-signatures
 -- ! BUILD_DIR: beam-sqlite/examples/
 -- ! EXTRA_DEPS: employee3common.hs employee3commonsql.hs
 module Main where

--- a/docs/tutorials/tutorial3.md
+++ b/docs/tutorials/tutorial3.md
@@ -17,7 +17,7 @@ the schema should be pretty familiar, so I'm going to skip the explanation.
 
 ```haskell
 data ProductT f = Product
-                { _productId          :: C f (Auto Int)
+                { _productId          :: C f Int
                 , _productTitle       :: C f Text
                 , _productDescription :: C f Text
                 , _productPrice       :: C f Int {- Price in cents -} }
@@ -26,7 +26,7 @@ type Product = ProductT Identity
 deriving instance Show Product
 
 instance Table ProductT where
-  data PrimaryKey ProductT f = ProductId (Columnar f (Auto Int))
+  data PrimaryKey ProductT f = ProductId (Columnar f Int)
                                deriving Generic
   primaryKey = ProductId . _productId
 
@@ -51,7 +51,7 @@ import Data.Time
 deriving instance Show (PrimaryKey AddressT Identity)
 
 data OrderT f = Order
-              { _orderId      :: Columnar f (Auto Int)
+              { _orderId      :: Columnar f Int
               , _orderDate    :: Columnar f LocalTime
               , _orderForUser :: PrimaryKey UserT f
               , _orderShipToAddress :: PrimaryKey AddressT f
@@ -61,7 +61,7 @@ type Order = OrderT Identity
 deriving instance Show Order
 
 instance Table OrderT where
-    data PrimaryKey OrderT f = OrderId (Columnar f (Auto Int))
+    data PrimaryKey OrderT f = OrderId (Columnar f Int)
                                deriving Generic
     primaryKey = OrderId . _orderId
 
@@ -72,7 +72,7 @@ data ShippingCarrier = USPS | FedEx | UPS | DHL
                        deriving (Show, Read, Eq, Ord, Enum)
 
 data ShippingInfoT f = ShippingInfo
-                     { _shippingInfoId             :: Columnar f (Auto Int)
+                     { _shippingInfoId             :: Columnar f Int
                      , _shippingInfoCarrier        :: Columnar f ShippingCarrier
                      , _shippingInfoTrackingNumber :: Columnar f Text }
                        deriving Generic
@@ -80,7 +80,7 @@ type ShippingInfo = ShippingInfoT Identity
 deriving instance Show ShippingInfo
 
 instance Table ShippingInfoT where
-    data PrimaryKey ShippingInfoT f = ShippingInfoId (Columnar f (Auto Int))
+    data PrimaryKey ShippingInfoT f = ShippingInfoId (Columnar f Int)
                                       deriving Generic
     primaryKey = ShippingInfoId . _shippingInfoId
 
@@ -199,38 +199,38 @@ let users@[james, betty, sam] =
           [ User "james@example.com" "James" "Smith"  "b4cc344d25a2efe540adbf2678e2304c" {- james -}
           , User "betty@example.com" "Betty" "Jones"  "82b054bd83ffad9b6cf8bdb98ce3cc2f" {- betty -}
           , User "sam@example.com"   "Sam"   "Taylor" "332532dcfaa1cbf61e2a266bd723612c" {- sam -} ]
-    addresses = [ Address (Auto Nothing) "123 Little Street" Nothing "Boston" "MA" "12345" (pk james)
+    addresses = [ Address default_ (val_ "123 Little Street") (val_ Nothing) (val_ "Boston") (val_ "MA") (val_ "12345") (pk james)
+                , Address default_ (val_ "222 Main Street") (val_ (Just "Ste 1")) (val_ "Houston") (val_ "TX") (val_ "8888") (pk betty)
+                , Address default_ (val_ "9999 Residence Ave") (val_ Nothing) (val_ "Sugarland") (val_ "TX") (val_ "8989") (pk betty) ]
 
-                , Address (Auto Nothing) "222 Main Street" (Just "Ste 1") "Houston" "TX" "8888" (pk betty)
-                , Address (Auto Nothing) "9999 Residence Ave" Nothing "Sugarland" "TX" "8989" (pk betty) ]
-
-    products = [ Product (Auto Nothing) "Red Ball" "A bright red, very spherical ball" 1000
-               , Product (Auto Nothing) "Math Textbook" "Contains a lot of important math theorems and formulae" 2500
-               , Product (Auto Nothing) "Intro to Haskell" "Learn the best programming language in the world" 3000
-               , Product (Auto Nothing) "Suitcase" "A hard durable suitcase" 15000 ]
+    products = [ Product default_ (val_ "Red Ball") (val_ "A bright red, very spherical ball") (val_ 1000)
+               , Product default_ (val_ "Math Textbook") (val_ "Contains a lot of important math theorems and formulae") (val_ 2500)
+               , Product default_ (val_ "Intro to Haskell") (val_ "Learn the best programming language in the world") (val_ 3000)
+               , Product default_ (val_ "Suitcase") "A hard durable suitcase" 15000 ]
 
 (jamesAddress1, bettyAddress1, bettyAddress2, redBall, mathTextbook, introToHaskell, suitcase) <-
   withDatabaseDebug putStrLn conn $ do
     runInsert $ insert (shoppingCartDb ^. shoppingCartUsers) $
                 insertValues users
-  
+
     [jamesAddress1, bettyAddress1, bettyAddress2] <-
       runInsertReturningList $
-      insertReturning (shoppingCartDb ^. shoppingCartUserAddresses) $ insertValues addresses
-      
+      insertReturning (shoppingCartDb ^. shoppingCartUserAddresses) $ insertExpressions addresses
+
     [redBall, mathTextbook, introToHaskell, suitcase] <-
       runInsertReturningList $
-      insertReturning (shoppingCartDb ^. shoppingCartProducts) $ insertValues products
-      
+      insertReturning (shoppingCartDb ^. shoppingCartProducts) $ insertExpressions products
+
     pure ( jamesAddress1, bettyAddress1, bettyAddress2, redBall, mathTextbook, introToHaskell, suitcase )
 ```
 
-Now, if we take a look at one of the returned addresses, like `jamesAddress1`,
-we see it has had it's `Auto` field assigned correctly.
+Now, if we take a look at one of the returned addresses, like
+`jamesAddress1`, we see it has had the `default_` values assigned
+correctly.
 
 ```haskell
 Prelude Database.Beam Database.Beam.Sqlite Data.Time Database.SQLite.Simple Data.Text Lens.Micro> jamesAddress1
-Address {_addressId = Auto {unAuto = Just 1}, _addressLine1 = "123 Little Street", _addressLine2 = Nothing, _addressCity = "Boston", _addressState = "MA", _addressZip = "12345", _addressForUser = UserId "james@example.com"}
+Address {_addressId = 1, _addressLine1 = "123 Little Street", _addressLine2 = Nothing, _addressCity = "Boston", _addressState = "MA", _addressZip = "12345", _addressForUser = UserId "james@example.com"}
 ```
 
 !!! note "Note"
@@ -238,7 +238,7 @@ Address {_addressId = Auto {unAuto = Just 1}, _addressLine1 = "123 Little Street
     package. They emulate the `INSERT .. RETURNING ..` functionatily you may
     expect in other databases. Because this emulation is backend-specific it is
     part of the backend package, rather than `beam-core`.
-    
+
     Other backends may have similar functionality. Please refer to the backend
     package you're interested in for more information, as well as notes on the
     implementation.
@@ -249,12 +249,12 @@ Now we can insert shipping information. Of course, the shipping information
 contains the `ShippingCarrier` enumeration.
 
 ```haskell
-bettyShippingInfo <- 
+bettyShippingInfo <-
   withDatabaseDebug putStrLn conn $ do
     [bettyShippingInfo] <-
       runInsertReturningList $
       insertReturning (shoppingCartDb ^. shoppingCartShippingInfos) $
-      insertValues [ ShippingInfo (Auto Nothing) USPS "12345790ABCDEFGHI" ]
+      insertExpressions [ ShippingInfo default_ (val_ USPS) (val_ "12345790ABCDEFGHI") ]
     pure bettyShippingInfo
 ```
 
@@ -268,13 +268,13 @@ If you run this, you'll get an error from GHCi.
     * In a stmt of a 'do' block:
         [bettyShippingInfo] <- runInsertReturningList
                                $ insertReturning (shoppingCartDb ^. shoppingCartShippingInfos)
-                                 $ insertValues
-                                     [ShippingInfo (Auto Nothing) USPS "12345790ABCDEFGHI"]
+                                 $ insertExpressions
+                                     [ShippingInfo default_ (val_ USPS) (val_ "12345790ABCDEFGHI")]
       In the second argument of '($)', namely
         'do { [bettyShippingInfo] <- runInsertReturningList
                                      $ insertReturning (shoppingCartDb ^. shoppingCartShippingInfos)
-                                       $ insertValues
-                                           [ShippingInfo (Auto Nothing) USPS "12345790ABCDEFGHI"];
+                                       $ insertExpressions
+                                           [ShippingInfo default_ (val_ USPS) (val_ "12345790ABCDEFGHI")];
               pure bettyShippingInfo }''
       In the first argument of 'GHC.GHCi.ghciStepIO ::
                                   forall a. IO a -> IO a', namely
@@ -282,26 +282,26 @@ If you run this, you'll get an error from GHCi.
          $ do { [bettyShippingInfo] <- runInsertReturningList
                                        $ insertReturning
                                            (shoppingCartDb ^. shoppingCartShippingInfos)
-                                         $ insertValues
-                                             [ShippingInfo (Auto Nothing) USPS "12345790ABCDEFGHI"];
+                                         $ insertExpressions
+                                             [ShippingInfo default_ (val_ USPS) (val_ "12345790ABCDEFGHI")];
                 pure bettyShippingInfo }'
 
 <interactive>:265:7: error:
     * No instance for (Database.Beam.Backend.SQL.SQL92.HasSqlValueSyntax
                          SqliteValueSyntax ShippingCarrier)
-        arising from a use of 'insertValues'
+        arising from a use of 'insertExpressions'
     * In the second argument of '($)', namely
-        'insertValues
-           [ShippingInfo (Auto Nothing) USPS "12345790ABCDEFGHI"]''
+        'insertExpressions
+           [ShippingInfo default_ (val_ USPS) (val_ "12345790ABCDEFGHI")]''
       In the second argument of '($)', namely
         'insertReturning (shoppingCartDb ^. shoppingCartShippingInfos)
-         $ insertValues
-             [ShippingInfo (Auto Nothing) USPS "12345790ABCDEFGHI"]'
+         $ insertExpressions
+             [ShippingInfo default_ (val_ USPS) (val_ "12345790ABCDEFGHI")]'
       In a stmt of a 'do' block:
         [bettyShippingInfo] <- runInsertReturningList
                                $ insertReturning (shoppingCartDb ^. shoppingCartShippingInfos)
-                                 $ insertValues
-                                     [ShippingInfo (Auto Nothing) USPS "12345790ABCDEFGHI"]
+                                 $ insertExpressions
+                                     [ShippingInfo default_ (val_ USPS) (val_ "12345790ABCDEFGHI")]
 ```
 
 These errors are because there's no way to express a `ShippingCarrier` in the
@@ -365,12 +365,12 @@ instance FromBackendRow be ShippingCarrier
 Now, if we try to insert the shipping info again, it works.
 
 ```haskell
-bettyShippingInfo <- 
+bettyShippingInfo <-
   withDatabaseDebug putStrLn conn $ do
     [bettyShippingInfo] <-
       runInsertReturningList $
       insertReturning (shoppingCartDb ^. shoppingCartShippingInfos) $
-      insertValues [ ShippingInfo (Auto Nothing) USPS "12345790ABCDEFGHI" ]
+      insertExpressions [ ShippingInfo default_ (val_ USPS) (val_ "12345790ABCDEFGHI") ]
     pure bettyShippingInfo
 ```
 
@@ -379,15 +379,14 @@ stored correctly.
 
 ```haskell
 > bettyShippingInfo
-ShippingInfo {_shippingInfoId = Auto {unAuto = Just 1}, _shippingInfoCarrier = USPS, _shippingInfoTrackingNumber = "12345790ABCDEFGHI"}
+ShippingInfo {_shippingInfoId = 1, _shippingInfoCarrier = USPS, _shippingInfoTrackingNumber = "12345790ABCDEFGHI"}
 ```
 
-Now, let's insert some orders that just came in. In the previous `INSERT`
-examples, we used `insertValues` to insert arbitrary values into the database.
-Now, we want to insert transactions with the current database timestamp (i.e.,
-`CURRENT_TIMESTAMP` in SQL). We can insert rows containing arbitrary expressions
-using the `insertExpressions` function. As you can see, the resulting rows have
-a timestamp set by the database.
+Now, let's insert some orders that just came in. We want to insert
+transactions with the current database timestamp (i.e.,
+`CURRENT_TIMESTAMP` in SQL). We can do this using
+`insertExpressions`. If you run the example below, you'll see the
+resulting rows have a timestamp set by the database.
 
 !beam-query
 ```haskell
@@ -398,10 +397,10 @@ a timestamp set by the database.
     runInsertReturningList $
       insertReturning (shoppingCartDb ^. shoppingCartOrders) $
       insertExpressions $
-      [ Order (val_ (Auto Nothing)) currentTimestamp_ (val_ (pk james)) (val_ (pk jamesAddress1)) nothing_ 
-      , Order (val_ (Auto Nothing)) currentTimestamp_ (val_ (pk betty)) (val_ (pk bettyAddress1)) (just_ (val_ (pk bettyShippingInfo))) 
-      , Order (val_ (Auto Nothing)) currentTimestamp_ (val_ (pk james)) (val_ (pk jamesAddress1)) nothing_ ]
-      
+      [ Order default_ currentTimestamp_ (val_ (pk james)) (val_ (pk jamesAddress1)) nothing_
+      , Order default_ currentTimestamp_ (val_ (pk betty)) (val_ (pk bettyAddress1)) (just_ (val_ (pk bettyShippingInfo)))
+      , Order default_ currentTimestamp_ (val_ (pk james)) (val_ (pk jamesAddress1)) nothing_ ]
+
 print jamesOrder1
 print bettyOrder1
 print jamesOrder2
@@ -447,7 +446,7 @@ usersAndOrders <-
       user  <- all_ (shoppingCartDb ^. shoppingCartUsers)
       order <- leftJoin_ (all_ (shoppingCartDb ^. shoppingCartOrders)) (\order -> _orderForUser order `references_` user)
       pure (user, order)
-      
+
 mapM_ print usersAndOrders
 ```
 
@@ -472,7 +471,7 @@ usersWithNoOrders <-
       order <- leftJoin_ (all_ (shoppingCartDb ^. shoppingCartOrders)) (\order -> _orderForUser order `references_` user)
       guard_ (isNothing_ order)
       pure user
-      
+
 mapM_ print usersWithNoOrders
 ```
 
@@ -491,7 +490,7 @@ usersWithNoOrders <-
       user  <- all_ (shoppingCartDb ^. shoppingCartUsers)
       guard_ (not_ (exists_ (filter_ (\order -> _orderForUser order `references_` user) (all_ (shoppingCartDb ^. shoppingCartOrders)))))
       pure user
-      
+
 mapM_ print usersWithNoOrders
 ```
 
@@ -516,7 +515,7 @@ ordersWithCostOrdered <-
        order    <- related_ (shoppingCartDb ^. shoppingCartOrders) (_lineItemInOrder lineItem)
        product  <- related_ (shoppingCartDb ^. shoppingCartProducts) (_lineItemForProduct lineItem)
        pure (order, lineItem, product)
-       
+
 mapM_ print ordersWithCostOrdered
 ```
 
@@ -552,7 +551,7 @@ allUsersAndTotals <-
        product  <- leftJoin_ (all_ (shoppingCartDb ^. shoppingCartProducts))
                              (\product -> maybe_ (val_ False) (\lineItem -> _lineItemForProduct lineItem `references_` product) lineItem)
        pure (user, lineItem, product)
-       
+
 mapM_ print allUsersAndTotals
 ```
 
@@ -576,7 +575,7 @@ allUnshippedOrders <-
     select $
     filter_ (isNothing_ . _orderShippingInfo) $
     all_ (shoppingCartDb ^. shoppingCartOrders)
-    
+
 mapM_ print allUnshippedOrders
 ```
 
@@ -599,7 +598,7 @@ shippingInformationByUser <-
     do user  <- all_ (shoppingCartDb ^. shoppingCartUsers)
        order <- leftJoin_ (all_ (shoppingCartDb ^. shoppingCartOrders)) (\order -> _orderForUser order `references_` user)
        pure (user, order)
-       
+
 mapM_ print shippingInformationByUser
 ```
 
@@ -629,16 +628,16 @@ shippingInformationByUser <-
     runSelectReturningList $
     select $
     do user <- all_ (shoppingCartDb ^. shoppingCartUsers)
-    
+
        (userEmail, unshippedCount) <-
          aggregate_ (\(userEmail, order) -> (group_ userEmail, countAll_)) $
          do user  <- all_ (shoppingCartDb ^. shoppingCartUsers)
             order <- leftJoin_ (all_ (shoppingCartDb ^. shoppingCartOrders))
                                (\order -> _orderForUser order `references_` user &&. isNothing_ (_orderShippingInfo order))
             pure (pk user, order)
-        
+
        guard_ (userEmail `references_` user)
-       
+
        (userEmail, shippedCount) <-
          aggregate_ (\(userEmail, order) -> (group_ userEmail, countAll_)) $
          do user  <- all_ (shoppingCartDb ^. shoppingCartUsers)
@@ -668,7 +667,7 @@ shippingInformationByUser <-
     runSelectReturningList $
     select $
     do user <- all_ (shoppingCartDb ^. shoppingCartUsers)
-    
+
        (userEmail, unshippedCount) <-
          subselect_ $
          aggregate_ (\(userEmail, order) -> (group_ userEmail, countAll_)) $
@@ -676,9 +675,9 @@ shippingInformationByUser <-
             order <- leftJoin_ (all_ (shoppingCartDb ^. shoppingCartOrders))
                                (\order -> _orderForUser order `references_` user &&. isNothing_ (_orderShippingInfo order))
             pure (pk user, order)
-        
+
        guard_ (userEmail `references_` user)
-       
+
        (userEmail, shippedCount) <-
          subselect_ $
          aggregate_ (\(userEmail, order) -> (group_ userEmail, countAll_)) $
@@ -705,4 +704,3 @@ havailable on [hackage](http://hackage.haskell.org/package/beam). Happy beaming!
 
 Beam is a work in progress. Please submit bugs and patches
 on [GitHub](https://github.com/tathougies/beam).
-

--- a/docs/user-guide/models.md
+++ b/docs/user-guide/models.md
@@ -296,17 +296,6 @@ constraints between tables in your data types. This is because references are a
 property of the database, not a particular table schema. Such relationships can
 be defined using `beam-migrate` library.
 
-
-## `Auto` fields
-
-Above, `Post` used `Auto Int` as the type for `postId`. `
-
-The `Auto` type constructor is provided by `beam-core` for fields that are
-automatically assigned by the database. Internally, `Auto x` is simply a newtype
-over `Maybe x`. The guarantee is that all values of type `Auto x` returned by
-beam in the result set will have a value, although this guarantee is not
-enforced at the type level (yet).
-
 ## Embedding
 
 Sometimes, we want to declare multiple models with fields in common. Beam allows


### PR DESCRIPTION
A lot of changes in this one.

The old `SqlEq` instances were shown to be incorrect in the presence of NULL. There are some fancy ways to get around this, but the most straightforward way, and ultimately -- the most correct -- is to explicitly declare which types can be checked for equality, and provide appropriate instances on a per-backend basis.

While I was adding the appropriate instances, I had to add instances for `Auto`. As discussed previously, `Auto` is a bad idea, so I ended up removing that from the code.

While doing that, I updated the docs to reflect the new change, and made some improvements to postgres `ON CONFLICT` along the way, to get the new docs to compile.

Partially helps #157 and should fix #160 