### PR TITLE
Migration zoned time

### DIFF
--- a/beam-migrate/Database/Beam/Migrate/SQL/Tables.hs
+++ b/beam-migrate/Database/Beam/Migrate/SQL/Tables.hs
@@ -28,7 +28,7 @@ module Database.Beam.Migrate.SQL.Tables
   , char, varchar, double
   , characterLargeObject, binaryLargeObject, array
   , boolean, numeric, date, time
-  , timestamp, timestamptz, zonedtimestamptz
+  , timestamp, timestamptz
   , binary, varbinary
 
   , maybeType
@@ -322,11 +322,8 @@ numeric :: IsSql92DataTypeSyntax syntax => Maybe (Word, Maybe Word) -> DataType 
 numeric x = DataType (numericType x)
 
 -- | SQL92 @TIMESTAMP WITH TIME ZONE@ data type
-timestamptz :: IsSql92DataTypeSyntax syntax => DataType syntax LocalTime
+timestamptz :: IsSql92DataTypeSyntax syntax => DataType syntax ZonedTime
 timestamptz = DataType (timestampType Nothing True)
-
-zonedtimestamptz :: IsSql92DataTypeSyntax syntax => DataType syntax ZonedTime
-zonedtimestamptz = DataType (timestampType Nothing True)
 
 -- | SQL92 @TIMESTAMP WITHOUT TIME ZONE@ data type
 timestamp :: IsSql92DataTypeSyntax syntax => DataType syntax LocalTime

--- a/beam-migrate/Database/Beam/Migrate/SQL/Tables.hs
+++ b/beam-migrate/Database/Beam/Migrate/SQL/Tables.hs
@@ -28,7 +28,7 @@ module Database.Beam.Migrate.SQL.Tables
   , char, varchar, double
   , characterLargeObject, binaryLargeObject, array
   , boolean, numeric, date, time
-  , timestamp, timestamptz
+  , timestamp, timestamptz, zonedtimestamptz
   , binary, varbinary
 
   , maybeType
@@ -56,7 +56,7 @@ import Data.Text (Text)
 import Data.Vector (Vector)
 import Data.ByteString (ByteString)
 import Data.Typeable
-import Data.Time (LocalTime, TimeOfDay)
+import Data.Time (LocalTime, TimeOfDay, ZonedTime)
 import Data.Scientific (Scientific)
 
 import GHC.TypeLits
@@ -324,6 +324,9 @@ numeric x = DataType (numericType x)
 -- | SQL92 @TIMESTAMP WITH TIME ZONE@ data type
 timestamptz :: IsSql92DataTypeSyntax syntax => DataType syntax LocalTime
 timestamptz = DataType (timestampType Nothing True)
+
+zonedtimestamptz :: IsSql92DataTypeSyntax syntax => DataType syntax ZonedTime
+zonedtimestamptz = DataType (timestampType Nothing True)
 
 -- | SQL92 @TIMESTAMP WITHOUT TIME ZONE@ data type
 timestamp :: IsSql92DataTypeSyntax syntax => DataType syntax LocalTime


### PR DESCRIPTION
- Made `timestamptz` return `ZonedTime` as `LocalTime` has no `TimeZone`.
Closes #162 