### PR TITLE
Fix SQLite migration bug

### DIFF
--- a/beam-sqlite/Database/Beam/Sqlite/Migrate.hs
+++ b/beam-sqlite/Database/Beam/Sqlite/Migrate.hs
@@ -139,7 +139,7 @@ parseSqliteDataType txt =
                doubleP <|> integerP <|>
                smallIntP <|> bigIntP <|> floatP <|>
                doubleP <|> realP <|> dateP <|>
-               timeP <|> timestampP <|> textP <|>
+               timestampP <|> timeP <|> textP <|>
                blobP <|> booleanP
 
     ws = A.many1 A.space


### PR DESCRIPTION
The SQLite migration engine would incorrectly label fields
of type 'TIMESTAMP' as fields of type 'TIME'. This is because
the SQLite type parser is greedy and the 'TIME' parser came first.

This reorders the timestamp and time parser so we get correctly
typed columns