### PR TITLE
Remove functional dependencies `be -> m`, `handle -> m` on MonadBeam

### DIFF
--- a/beam-core/Database/Beam/Backend/SQL.hs
+++ b/beam-core/Database/Beam/Backend/SQL.hs
@@ -33,7 +33,7 @@ import Control.Monad.IO.Class
 --   are supported in individual backends. See the documentation of those
 --   backends for more details.
 class (BeamBackend be, Monad m, MonadIO m, Sql92SanityCheck syntax) =>
-  MonadBeam syntax be handle m | m -> syntax be handle, be -> m, handle -> m where
+  MonadBeam syntax be handle m | m -> syntax be handle where
 
   {-# MINIMAL withDatabaseDebug, runReturningMany #-}
 

--- a/beam-migrate-cli/Database/Beam/Migrate/Tool/Diff.hs
+++ b/beam-migrate-cli/Database/Beam/Migrate/Tool/Diff.hs
@@ -105,7 +105,7 @@ getPredicatesFromSpec cmdLine reg (PredicateFetchSourceDbHead (MigrationDatabase
                   runSelectReturningOne $ select $
                   limit_ 1 $ offset_ (fromIntegral fromHead) $
                   orderBy_ (desc_ . _logEntryId) $
-                  all_ (_beamMigrateLogEntries (beamMigrateDb @be @cmd))
+                  all_ (_beamMigrateLogEntries (beamMigrateDb @be @cmd @hdl @m))
 
       case logEntry of
         Left err -> throwIO (CouldNotFetchLog err)

--- a/beam-migrate-cli/Database/Beam/Migrate/Tool/Log.hs
+++ b/beam-migrate-cli/Database/Beam/Migrate/Tool/Log.hs
@@ -29,7 +29,7 @@ displayLog cmdLine@MigrateCmdLine { migrateDatabase = Just dbName } = do
       res <- transact (migrationDbConnString db) $
              runSelectReturningList $ select $
              orderBy_ (desc_ . _logEntryId) $
-             all_ (_beamMigrateLogEntries (beamMigrateDb @be))
+             all_ (_beamMigrateLogEntries (beamMigrateDb @be @cmd @hdl @m))
       case res of
         Left err -> throwIO (CouldNotFetchLog err)
         Right entries ->

--- a/beam-migrate/Database/Beam/Migrate/Log.hs
+++ b/beam-migrate/Database/Beam/Migrate/Log.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 -- | Contains a schema for beam migration tools. Used by the CLI and
 -- the managed migrations support here.
 module Database.Beam.Migrate.Log where
@@ -68,14 +69,14 @@ beamMigratableDb :: forall cmd be hdl m
                     , Sql92SerializableDataTypeSyntax (Sql92DdlCommandDataTypeSyntax cmd)
                     , MonadBeam cmd be hdl m )
                  => CheckedDatabaseSettings be BeamMigrateDb
-beamMigratableDb = runMigrationSilenced beamMigrateDbMigration
+beamMigratableDb = runMigrationSilenced $ beamMigrateDbMigration @cmd @be @hdl @m
 
 beamMigrateDb :: forall be cmd hdl m
                . ( Sql92SaneDdlCommandSyntax cmd
                  , Sql92SerializableDataTypeSyntax (Sql92DdlCommandDataTypeSyntax cmd)
                  , MonadBeam cmd be hdl m )
                => DatabaseSettings be BeamMigrateDb
-beamMigrateDb = unCheckDatabase beamMigratableDb
+beamMigrateDb = unCheckDatabase $ beamMigratableDb @cmd @be @hdl @m
 
 beamMigrateDbMigration ::  forall cmd be hdl m
                         . ( Sql92SaneDdlCommandSyntax cmd
@@ -105,7 +106,7 @@ getLatestLogEntry =
   runSelectReturningOne (select $
                          limit_ 1 $
                          orderBy_ (desc_ . _logEntryId) $
-                         all_ (_beamMigrateLogEntries (beamMigrateDb @be @cmd)))
+                         all_ (_beamMigrateLogEntries (beamMigrateDb @be @cmd @hdl @m)))
 
 updateSchemaToCurrent :: forall be cmd hdl m
                        . ( IsSql92Syntax cmd
@@ -116,7 +117,7 @@ updateSchemaToCurrent :: forall be cmd hdl m
                          , MonadBeam cmd be hdl m )
                       => m ()
 updateSchemaToCurrent =
-  runInsert (insert (_beamMigrateVersionTbl (beamMigrateDb @be @cmd)) (insertValues [BeamMigrateVersion beamMigrateSchemaVersion]))
+  runInsert (insert (_beamMigrateVersionTbl (beamMigrateDb @be @cmd @hdl @m)) (insertValues [BeamMigrateVersion beamMigrateSchemaVersion]))
 
 recordCommit :: forall be cmd hdl m
              . ( IsSql92Syntax cmd
@@ -134,7 +135,7 @@ recordCommit commitId = do
   logEntry <- getLatestLogEntry
   let nextLogEntryId = maybe 0 (succ . _logEntryId) logEntry
 
-  runInsert (insert (_beamMigrateLogEntries (beamMigrateDb @be @cmd))
+  runInsert (insert (_beamMigrateLogEntries (beamMigrateDb @be @cmd @hdl @m))
                     (insertExpressions
                      [ LogEntry (val_ nextLogEntryId)
                                 (val_ commitIdTxt)
@@ -157,7 +158,7 @@ ensureBackendTables be@BeamMigrationBackend { backendGetDbConstraints = getCs } 
       maxVersion <-
         runSelectReturningOne $ select $
         aggregate_ (\v -> max_ (_beamMigrateVersion v)) $
-        all_ (_beamMigrateVersionTbl (beamMigrateDb @be @cmd))
+        all_ (_beamMigrateVersionTbl (beamMigrateDb @be @cmd @hdl @m))
 
       case maxVersion of
         Nothing -> cleanAndCreateSchema
@@ -177,7 +178,7 @@ ensureBackendTables be@BeamMigrationBackend { backendGetDbConstraints = getCs } 
         Just totalCnt <-
           runSelectReturningOne $ select $
           aggregate_ (\_ -> as_ @Int countAll_) $
-          all_ (_beamMigrateLogEntries (beamMigrateDb @be @cmd))
+          all_ (_beamMigrateLogEntries (beamMigrateDb @be @cmd @hdl @m))
         when (totalCnt > 0) (fail "beam-migrate: No versioning information, but log entries present")
         runNoReturn (dropTableCmd (dropTableSyntax "beam_migration"))
 
@@ -186,7 +187,7 @@ ensureBackendTables be@BeamMigrationBackend { backendGetDbConstraints = getCs } 
       createSchema
 
     createSchema = do
-      _ <- executeMigration doStep (beamMigrateDbMigration @cmd @be)
+      _ <- executeMigration doStep (beamMigrateDbMigration @cmd @be @hdl @m)
       updateSchemaToCurrent
 
 checkForBackendTables :: BeamMigrationBackend cmd be hdl m -> m Bool


### PR DESCRIPTION
While it is convenient for inference, these dependencies make it impossible to naturally use a monad transformer on MonadBeam.