### PR TITLE
Remove `withDatabase` and `withDatabaseDebug` from `MonadBeam`.

### DIFF
--- a/beam-core/Database/Beam.hs
+++ b/beam-core/Database/Beam.hs
@@ -11,7 +11,7 @@
 module Database.Beam
      ( module Database.Beam.Query
      , module Database.Beam.Schema
-     , MonadBeam(withDatabase, withDatabaseDebug)
+     , MonadBeam(..)
      , FromBackendRow(..)
 
        -- * Re-exports

--- a/beam-core/Database/Beam/Backend.hs
+++ b/beam-core/Database/Beam/Backend.hs
@@ -1,6 +1,7 @@
 module Database.Beam.Backend
   ( module Database.Beam.Backend.Types
-  , MonadBeam(..) ) where
+  , MonadBeam(..)
+  ) where
 
 import Database.Beam.Backend.Types
 import Database.Beam.Backend.SQL

--- a/beam-core/Database/Beam/Backend/SQL.hs
+++ b/beam-core/Database/Beam/Backend/SQL.hs
@@ -3,47 +3,26 @@ module Database.Beam.Backend.SQL
   , module Database.Beam.Backend.SQL.Types
   , module Database.Beam.Backend.Types
 
-  , MonadBeam(..) ) where
+  , MonadBeam(..)
+  ) where
 
 import Database.Beam.Backend.SQL.SQL2003
 import Database.Beam.Backend.SQL.Types
 import Database.Beam.Backend.Types
 
-import Control.Monad.IO.Class
-
--- * MonadBeam class
-
--- | A class that ties together a Sql syntax, backend, handle, and monad type.
+-- | A class that ties together a Sql syntax, backend, and monad type.
 --
---   Intuitively, this allows you to write code that performs database commands
---   without having to know the underlying API. As long as you have an
---   appropriate handle from a database library that Beam can use, you can use
---   the 'MonadBeam' methods to execute the query.
---
---   Provided here is a low-level interface. Most often, you'll only need the
---   'withDatabase' and 'withDatabaseDebug' function. The 'run*' functions are
---   wrapped by the appropriate functions in "Database.Beam.Query".
+--   Provided here is a low-level interface for executing commands. The 'run*'
+--   functions are wrapped by the appropriate functions in 'Database.Beam.Query'.
 --
 --   This interface is very high-level and isn't meant to expose the full power
 --   of the underlying database. Namely, it only supports simple data retrieval
 --   strategies. More complicated strategies (for example, Postgres's @COPY@)
 --   are supported in individual backends. See the documentation of those
 --   backends for more details.
-class (BeamBackend be, Monad m, MonadIO m, Sql92SanityCheck syntax) =>
-  MonadBeam syntax be handle m | m -> syntax be handle where
-
-  {-# MINIMAL withDatabaseDebug, runReturningMany #-}
-
-  -- | Run a database action, and log debugging information about statements
-  --   executed using the specified 'IO' action.
-  withDatabaseDebug :: (String -> IO ()) -- ^ Database statement logging function
-                    -> handle            -- ^ The database connection handle against which to execute the action
-                    -> m a               -- ^ The database action
-                    -> IO a
-  withDatabase :: handle -> m a -> IO a
-
-  -- | Run a database action, but don't report any debug information
-  withDatabase = withDatabaseDebug (\_ -> pure ())
+class (BeamBackend be, Monad m, Sql92SanityCheck syntax) =>
+  MonadBeam syntax be m | m -> syntax be where
+  {-# MINIMAL runReturningMany #-}
 
   -- | Run a query determined by the given syntax, providing an action that will
   --   be called to consume the results from the database (if any). The action

--- a/beam-core/Database/Beam/Backend/SQL/BeamExtensions.hs
+++ b/beam-core/Database/Beam/Backend/SQL/BeamExtensions.hs
@@ -25,8 +25,8 @@ import Control.Monad.Identity
 
 -- | 'MonadBeam's that support returning the newly created rows of an @INSERT@ statement.
 --   Useful for discovering the real value of a defaulted value.
-class MonadBeam syntax be handle m =>
-  MonadBeamInsertReturning syntax be handle m | m -> syntax be handle, be -> m, handle -> m where
+class MonadBeam syntax be m =>
+  MonadBeamInsertReturning syntax be m | m -> syntax be where
   runInsertReturningList
     :: ( Beamable table
        , Projectible (Sql92ExpressionSyntax syntax) (table (QExpr (Sql92ExpressionSyntax syntax) ()))
@@ -38,8 +38,8 @@ class MonadBeam syntax be handle m =>
 
 -- | 'MonadBeam's that support returning the updated rows of an @UPDATE@ statement.
 --   Useful for discovering the new values of the updated rows.
-class MonadBeam syntax be handle m =>
-  MonadBeamUpdateReturning syntax be handle m | m -> syntax be handle, be -> m, handle -> m where
+class MonadBeam syntax be m =>
+  MonadBeamUpdateReturning syntax be m | m -> syntax be where
   runUpdateReturningList
     :: ( Beamable table
        , Projectible (Sql92ExpressionSyntax syntax) (table (QExpr (Sql92ExpressionSyntax syntax) ()))
@@ -52,8 +52,8 @@ class MonadBeam syntax be handle m =>
 -- | 'MonadBeam's that suppert returning rows that will be deleted by the given
 -- @DELETE@ statement. Useful for deallocating resources based on the value of
 -- deleted rows.
-class MonadBeam syntax be handle m =>
-  MonadBeamDeleteReturning syntax be handle m | m -> syntax be handle, be -> m, handle -> m where
+class MonadBeam syntax be m =>
+  MonadBeamDeleteReturning syntax be m | m -> syntax be where
   runDeleteReturningList
     :: ( Beamable table
        , Projectible (Sql92ExpressionSyntax syntax) (table (QExpr (Sql92ExpressionSyntax syntax) ()))

--- a/beam-core/Database/Beam/Backend/SQL/Builder.hs
+++ b/beam-core/Database/Beam/Backend/SQL/Builder.hs
@@ -506,6 +506,5 @@ instance BeamBackend SqlSyntaxBackend where
 newtype SqlSyntaxM a = SqlSyntaxM (IO a)
   deriving (Applicative, Functor, Monad, MonadIO)
 
-instance MonadBeam SqlSyntaxBuilder SqlSyntaxBackend SqlSyntaxBackend SqlSyntaxM where
-  withDatabaseDebug _ _ _ = fail "absurd"
+instance MonadBeam SqlSyntaxBuilder SqlSyntaxBackend SqlSyntaxM where
   runReturningMany _ _ = fail "absurd"

--- a/beam-core/Database/Beam/Backend/URI.hs
+++ b/beam-core/Database/Beam/Backend/URI.hs
@@ -3,8 +3,6 @@
 -- | Convenience methods for constructing backend-agnostic applications
 module Database.Beam.Backend.URI where
 
-import           Database.Beam.Backend.SQL
-
 import           Control.Exception
 
 import qualified Data.Map as M
@@ -24,8 +22,8 @@ data BeamOpenURIUnsupportedScheme = BeamOpenURIUnsupportedScheme String deriving
 instance Exception BeamOpenURIUnsupportedScheme
 
 data BeamURIOpener c where
-  BeamURIOpener :: MonadBeam syntax be hdl m
-                => c syntax be hdl m
+  BeamURIOpener :: c hdl m
+                -> (forall a. hdl -> m a -> IO a)
                 -> (URI -> IO (hdl, IO ()))
                 -> BeamURIOpener c
 newtype BeamURIOpeners c where
@@ -41,45 +39,46 @@ instance Monoid (BeamURIOpeners c) where
 
 data OpenedBeamConnection c where
   OpenedBeamConnection
-    :: MonadBeam syntax be hdl m
-    => { openedBeamDatabase :: c syntax be hdl m
-       , openedBeamHandle   :: hdl
+    :: { beamRunner          :: (forall a. hdl -> m a -> IO a)
+       , openedBeamDatabase  :: c hdl m
+       , openedBeamHandle    :: hdl
        , closeBeamConnection :: IO ()
      } -> OpenedBeamConnection c
 
-mkUriOpener :: MonadBeam syntax be hdl m
-            => String
+mkUriOpener :: (forall a. hdl -> m a -> IO a)
+            -> String
             -> (URI -> IO (hdl, IO ()))
-            -> c syntax be hdl m
+            -> c hdl m
             -> BeamURIOpeners c
-mkUriOpener schemeNm opener c = BeamURIOpeners (M.singleton schemeNm (BeamURIOpener c opener))
+mkUriOpener runner schemeNm opener c = BeamURIOpeners (M.singleton schemeNm (BeamURIOpener c runner opener))
 
 withDbFromUri :: forall c a
                . BeamURIOpeners c
               -> String
-              -> (forall syntax be hdl m. MonadBeam syntax be hdl m => c syntax be hdl m -> m a)
+              -> (forall hdl m. (forall r. hdl -> m r -> IO r) -> c
+                   hdl m -> m a)
               -> IO a
 withDbFromUri protos uri actionWithDb =
-  withDbConnection protos uri (\c hdl -> withDatabase hdl (actionWithDb c))
+  withDbConnection protos uri (\runner c hdl -> runner hdl (actionWithDb runner c))
 
 withDbConnection :: forall c a
                   . BeamURIOpeners c
                  -> String
-                 -> (forall syntax be hdl m. MonadBeam syntax be hdl m =>
-                      c syntax be hdl m -> hdl -> IO a)
+                 -> (forall hdl m. (forall r. hdl -> m r -> IO r) ->
+                      c hdl m -> hdl -> IO a)
                  -> IO a
 withDbConnection protos uri actionWithDb =
   bracket (openDbConnection protos uri) closeBeamConnection $
-  \(OpenedBeamConnection c hdl _) -> actionWithDb c hdl
+  \(OpenedBeamConnection runner c hdl _) -> actionWithDb runner c hdl
 
 openDbConnection :: forall c
                   . BeamURIOpeners c
                  -> String
                  -> IO (OpenedBeamConnection c)
 openDbConnection protos uri = do
-  (parsedUri, BeamURIOpener c openURI) <- findURIOpener protos uri
+  (parsedUri, BeamURIOpener c runner openURI) <- findURIOpener protos uri
   (hdl, closeHdl) <- openURI parsedUri
-  pure (OpenedBeamConnection c hdl closeHdl)
+  pure (OpenedBeamConnection runner c hdl closeHdl)
 
 findURIOpener :: BeamURIOpeners c -> String -> IO (URI, BeamURIOpener c)
 findURIOpener (BeamURIOpeners protos) uri =

--- a/beam-core/Database/Beam/Query.hs
+++ b/beam-core/Database/Beam/Query.hs
@@ -154,7 +154,7 @@ lookup_ tbl tblKey =
 
 -- | Run a 'SqlSelect' in a 'MonadBeam' and get the results as a list
 runSelectReturningList ::
-  (IsSql92Syntax cmd, MonadBeam cmd be hdl m, FromBackendRow be a) =>
+  (IsSql92Syntax cmd, MonadBeam cmd be m, FromBackendRow be a) =>
   SqlSelect (Sql92SelectSyntax cmd) a -> m [ a ]
 runSelectReturningList (SqlSelect s) =
   runReturningList (selectCmd s)
@@ -163,7 +163,7 @@ runSelectReturningList (SqlSelect s) =
 --   one. Both no results as well as more than one result cause this to return
 --   'Nothing'.
 runSelectReturningOne ::
-  (IsSql92Syntax cmd, MonadBeam cmd be hdl m, FromBackendRow be a) =>
+  (IsSql92Syntax cmd, MonadBeam cmd be m, FromBackendRow be a) =>
   SqlSelect (Sql92SelectSyntax cmd) a -> m (Maybe a)
 runSelectReturningOne (SqlSelect s) =
   runReturningOne (selectCmd s)
@@ -209,7 +209,7 @@ insert :: ( IsSql92InsertSyntax syntax, Projectible Text (table (QField s)) )
 insert tbl values = insertOnly tbl id values
 
 -- | Run a 'SqlInsert' in a 'MonadBeam'
-runInsert :: (IsSql92Syntax cmd, MonadBeam cmd be hdl m)
+runInsert :: (IsSql92Syntax cmd, MonadBeam cmd be m)
           => SqlInsert (Sql92InsertSyntax cmd) -> m ()
 runInsert SqlInsertNoRows = pure ()
 runInsert (SqlInsert i) = runNoReturn (insertCmd i)
@@ -341,7 +341,7 @@ save tbl@(DatabaseEntity (DatabaseTable _ tblSettings)) v =
       allBeamValues (\(Columnar' (TableField fieldNm)) -> fieldNm) (primaryKey tblSettings)
 
 -- | Run a 'SqlUpdate' in a 'MonadBeam'.
-runUpdate :: (IsSql92Syntax cmd, MonadBeam cmd be hdl m)
+runUpdate :: (IsSql92Syntax cmd, MonadBeam cmd be m)
           => SqlUpdate (Sql92UpdateSyntax cmd) tbl -> m ()
 runUpdate (SqlUpdate u) = runNoReturn (updateCmd u)
 runUpdate SqlIdentityUpdate = pure ()
@@ -364,6 +364,6 @@ delete (DatabaseEntity (DatabaseTable tblNm tblSettings)) mkWhere =
     QExpr where_ = mkWhere (changeBeamRep (\(Columnar' (TableField name)) -> Columnar' (QExpr (pure (fieldE (unqualifiedField name))))) tblSettings)
 
 -- | Run a 'SqlDelete' in a 'MonadBeam'
-runDelete :: (IsSql92Syntax cmd, MonadBeam cmd be hdl m)
+runDelete :: (IsSql92Syntax cmd, MonadBeam cmd be m)
           => SqlDelete (Sql92DeleteSyntax cmd) table -> m ()
 runDelete (SqlDelete d) = runNoReturn (deleteCmd d)

--- a/beam-migrate-cli/Database/Beam/Migrate/Tool/Diff.hs
+++ b/beam-migrate-cli/Database/Beam/Migrate/Tool/Diff.hs
@@ -91,7 +91,7 @@ getPredicatesFromSpec cmdLine reg (PredicateFetchSourceDbHead (MigrationDatabase
   SomeBeamMigrationBackend
     (BeamMigrationBackend { backendGetDbConstraints = getCs
                           , backendTransact = transact } ::
-        BeamMigrationBackend cmd be hdl m) <-
+        BeamMigrationBackend cmd be m) <-
     loadBackend' cmdLine modName
 
   case ref of
@@ -105,7 +105,7 @@ getPredicatesFromSpec cmdLine reg (PredicateFetchSourceDbHead (MigrationDatabase
                   runSelectReturningOne $ select $
                   limit_ 1 $ offset_ (fromIntegral fromHead) $
                   orderBy_ (desc_ . _logEntryId) $
-                  all_ (_beamMigrateLogEntries (beamMigrateDb @be @cmd @hdl @m))
+                  all_ (_beamMigrateLogEntries (beamMigrateDb @be @cmd @m))
 
       case logEntry of
         Left err -> throwIO (CouldNotFetchLog err)

--- a/beam-migrate-cli/Database/Beam/Migrate/Tool/Log.hs
+++ b/beam-migrate-cli/Database/Beam/Migrate/Tool/Log.hs
@@ -21,7 +21,7 @@ displayLog MigrateCmdLine { migrateDatabase = Nothing } =
 displayLog cmdLine@MigrateCmdLine { migrateDatabase = Just dbName } = do
   reg <- lookupRegistry cmdLine
 
-  (db, _, SomeBeamMigrationBackend (be :: BeamMigrationBackend cmd be hdl m)) <-
+  (db, _, SomeBeamMigrationBackend (be :: BeamMigrationBackend cmd be m)) <-
     loadBackend cmdLine reg dbName
 
   case be of
@@ -29,7 +29,7 @@ displayLog cmdLine@MigrateCmdLine { migrateDatabase = Just dbName } = do
       res <- transact (migrationDbConnString db) $
              runSelectReturningList $ select $
              orderBy_ (desc_ . _logEntryId) $
-             all_ (_beamMigrateLogEntries (beamMigrateDb @be @cmd @hdl @m))
+             all_ (_beamMigrateLogEntries (beamMigrateDb @be @cmd @m))
       case res of
         Left err -> throwIO (CouldNotFetchLog err)
         Right entries ->

--- a/beam-migrate-cli/Database/Beam/Migrate/Tool/Registry.hs
+++ b/beam-migrate-cli/Database/Beam/Migrate/Tool/Registry.hs
@@ -517,7 +517,7 @@ withoutMetadata =
     takeWhile (/="-- + BEAM-MIGRATE")
 
 readSchemaMetaData :: MigrationRegistry
-                   -> BeamMigrationBackend cmd be hdl m
+                   -> BeamMigrationBackend cmd be m
                    -> UUID
                    -> IO SchemaMetaData
 readSchemaMetaData reg BeamMigrationBackend { backendPredicateParsers = parsers } commitId = do

--- a/beam-migrate-cli/Database/Beam/Migrate/Tool/Schema.hs
+++ b/beam-migrate-cli/Database/Beam/Migrate/Tool/Schema.hs
@@ -174,7 +174,7 @@ showSimpleSchema cmdLine backend connStr = do
                 Right sch -> putStrLn sch
 
 writeSchema :: MigrateCmdLine -> MigrationRegistry
-             -> UUID -> BeamMigrationBackend cmd be hdl m
+             -> UUID -> BeamMigrationBackend cmd be m
              -> [SomeDatabasePredicate]
              -> IO FilePath
 writeSchema cmdLine registry commitId be cs = do
@@ -207,7 +207,7 @@ writeHsSchema cmdLine registry commitId cs dbSchema fmts =
                           metadataComment "--" metadata
 
 writeMigration :: MigrateCmdLine -> MigrationRegistry
-               -> BeamMigrationBackend cmd be hdl m
+               -> BeamMigrationBackend cmd be m
                -> UUID -> UUID
                -> [ cmd ]
                -> IO FilePath

--- a/beam-migrate-cli/Database/Beam/Migrate/Tool/Status.hs
+++ b/beam-migrate-cli/Database/Beam/Migrate/Tool/Status.hs
@@ -76,7 +76,7 @@ showCommit atTime sch = do
   putStrLn (T.unpack . T.unlines . map ("    " <>) .
              T.lines . registeredSchemaInfoMessage $ sch)
 
-hasBackendTables :: String -> BeamMigrationBackend cmd be hdl m -> IO Bool
+hasBackendTables :: String -> BeamMigrationBackend cmd be m -> IO Bool
 hasBackendTables connStr be@BeamMigrationBackend { backendTransact = transact } =
   do res <- transact connStr (checkForBackendTables be)
      case res of

--- a/beam-migrate/Database/Beam/Migrate/Backend.hs
+++ b/beam-migrate/Database/Beam/Migrate/Backend.hs
@@ -72,9 +72,9 @@ type DdlError = String
 -- | Backends should create a value of this type and export it in an exposed
 -- module under the name 'migrationBackend'. See the module documentation for
 -- more details.
-data BeamMigrationBackend commandSyntax be hdl m where
+data BeamMigrationBackend commandSyntax be m where
   BeamMigrationBackend ::
-    ( MonadBeam commandSyntax be hdl m
+    ( MonadBeam commandSyntax be m
     , Typeable be
     , HasQBuilder (Sql92SelectSyntax commandSyntax)
     , HasSqlValueSyntax (Sql92ValueSyntax commandSyntax) LocalTime
@@ -95,7 +95,7 @@ data BeamMigrationBackend commandSyntax be hdl m where
     , backendConvertToHaskell :: HaskellPredicateConverter
     , backendActionProvider :: ActionProvider commandSyntax
     , backendTransact :: forall a. String -> m a -> IO (Either DdlError a)
-    } -> BeamMigrationBackend commandSyntax be hdl m
+    } -> BeamMigrationBackend commandSyntax be m
 
 -- | Monomorphic wrapper for use with plugin loaders that cannot handle
 -- polymorphism
@@ -104,7 +104,7 @@ data SomeBeamMigrationBackend where
                               , IsSql92DdlCommandSyntax commandSyntax
                               , IsSql92Syntax commandSyntax
                               , Sql92SanityCheck commandSyntax ) =>
-                              BeamMigrationBackend commandSyntax be hdl m
+                              BeamMigrationBackend commandSyntax be m
                            -> SomeBeamMigrationBackend
 
 -- | In order to support Haskell schema generation, backends need to provide a

--- a/beam-migrate/Database/Beam/Migrate/Simple.hs
+++ b/beam-migrate/Database/Beam/Migrate/Simple.hs
@@ -24,7 +24,6 @@ module Database.Beam.Migrate.Simple
 import           Prelude hiding (log)
 
 import           Database.Beam
-import           Database.Beam.Backend.SQL
 import           Database.Beam.Migrate.Backend
 import           Database.Beam.Migrate.Types
 import           Database.Beam.Migrate.Actions
@@ -92,7 +91,7 @@ defaultUpToDateHooks =
 -- Tries to bring the database up to date, using the database log and the given
 -- 'MigrationSteps'. Fails if the migration is irreversible, or an error occurs.
 bringUpToDate :: Database be db
-              => BeamMigrationBackend cmd be hdl m
+              => BeamMigrationBackend cmd be m
               -> MigrationSteps cmd () (CheckedDatabaseSettings be db)
               -> m (Maybe (CheckedDatabaseSettings be db))
 bringUpToDate be@BeamMigrationBackend {} =
@@ -105,17 +104,17 @@ bringUpToDate be@BeamMigrationBackend {} =
 -- Accepts a set of hooks that can be used to customize behavior. See the
 -- documentation for 'BringUpToDateHooks' for more information. Calling this
 -- with 'defaultUpToDateHooks' is the same as using 'bringUpToDate'.
-bringUpToDateWithHooks :: forall db cmd be hdl m
+bringUpToDateWithHooks :: forall db cmd be m
                         . Database be db
                        => BringUpToDateHooks m
-                       -> BeamMigrationBackend cmd be hdl m
+                       -> BeamMigrationBackend cmd be m
                        -> MigrationSteps cmd () (CheckedDatabaseSettings be db)
                        -> m (Maybe (CheckedDatabaseSettings be db))
 bringUpToDateWithHooks hooks be@(BeamMigrationBackend { backendRenderSyntax = renderSyntax' }) steps = do
   ensureBackendTables be
 
   entries <- runSelectReturningList $ select $
-             all_ (_beamMigrateLogEntries (beamMigrateDb @be @cmd @hdl @m))
+             all_ (_beamMigrateLogEntries (beamMigrateDb @be @cmd @m))
   let verifyMigration :: Int -> T.Text -> Migration cmd a -> StateT [LogEntry] (WriterT (Max Int) m) a
       verifyMigration stepIx stepNm step =
         do log <- get
@@ -161,7 +160,7 @@ bringUpToDateWithHooks hooks be@(BeamMigrationBackend { backendRenderSyntax = re
                          runNoReturn cmd)
                      step
 
-                 runInsert $ insert (_beamMigrateLogEntries (beamMigrateDb @be @cmd @hdl @m)) $
+                 runInsert $ insert (_beamMigrateLogEntries (beamMigrateDb @be @cmd @m)) $
                    insertExpressions [ LogEntry (val_ stepIx) (val_ stepName) currentTimestamp_ ]
                  endStepHook hooks stepIx stepName
 
@@ -188,7 +187,7 @@ simpleSchema provider settings =
 --
 -- May 'fail' if we cannot find a schema
 createSchema :: Database be db
-             => BeamMigrationBackend cmd be hdl m
+             => BeamMigrationBackend cmd be m
              -> CheckedDatabaseSettings be db
              -> m ()
 createSchema BeamMigrationBackend { backendActionProvider = actions } db =
@@ -202,7 +201,7 @@ createSchema BeamMigrationBackend { backendActionProvider = actions } db =
 -- 'fail') if this involves an irreversible migration (one that may result in
 -- data loss).
 autoMigrate :: Database be db
-            => BeamMigrationBackend cmd be hdl m
+            => BeamMigrationBackend cmd be m
             -> CheckedDatabaseSettings be db
             -> m ()
 autoMigrate BeamMigrationBackend { backendActionProvider = actions
@@ -224,15 +223,16 @@ autoMigrate BeamMigrationBackend { backendActionProvider = actions
 --
 -- 'BeamMigrationBackend's can usually be found in a module named
 -- @Database.Beam.<Backend>.Migrate@ with the name@migrationBackend@
-simpleMigration :: ( MonadBeam cmd be handle m
+simpleMigration :: ( MonadBeam cmd be m
                  ,   Database be db )
-                => BeamMigrationBackend cmd be handle m
+                => (forall a. handle -> m a -> IO a)
+                -> BeamMigrationBackend cmd be m
                 -> handle
                 -> CheckedDatabaseSettings be db
                 -> IO (Maybe [cmd])
-simpleMigration BeamMigrationBackend { backendGetDbConstraints = getCs
-                                     , backendActionProvider = action } hdl db = do
-  pre <- withDatabase hdl getCs
+simpleMigration runner BeamMigrationBackend { backendGetDbConstraints = getCs
+                                            , backendActionProvider = action } hdl db = do
+  pre <- runner hdl getCs
 
   let post = collectChecks db
       solver = heuristicSolver action pre post
@@ -250,8 +250,8 @@ data VerificationResult
 -- | Verify that the given, beam database matches the actual
 -- schema. On success, returns 'VerificationSucceeded', on failure,
 -- returns 'VerificationFailed' and a list of missing predicates.
-verifySchema :: ( Database be db, MonadBeam cmd be handle m )
-             => BeamMigrationBackend cmd be handle m
+verifySchema :: ( Database be db, MonadBeam cmd be m )
+             => BeamMigrationBackend cmd be m
              -> CheckedDatabaseSettings be db
              -> m VerificationResult
 verifySchema BeamMigrationBackend { backendGetDbConstraints = getConstraints } db =
@@ -263,10 +263,14 @@ verifySchema BeamMigrationBackend { backendGetDbConstraints = getConstraints } d
        else pure (VerificationFailed (HS.toList missingPredicates))
 
 -- | Run a sequence of commands on a database
-runSimpleMigration :: forall cmd be hdl m . MonadBeam cmd be hdl m
-                   => hdl -> [cmd] -> IO ()
-runSimpleMigration hdl =
-  withDatabase @cmd @be @hdl @m hdl . mapM_ runNoReturn
+runSimpleMigration :: forall cmd be hdl m
+                   .  MonadBeam cmd be m
+                   => (forall a. hdl -> m a -> IO a)
+                   -> hdl
+                   -> [cmd]
+                   -> IO ()
+runSimpleMigration runner hdl =
+  runner hdl . mapM_ runNoReturn
 
 -- | Given a function to convert a command to a 'String', produce a script that
 -- will execute the given migration. Usually, the function you provide
@@ -293,8 +297,8 @@ backendMigrationScript render mig =
 --
 -- Backends that have a migration backend typically export it under the module
 -- name @Database.Beam./Backend/.Migrate@.
-haskellSchema :: MonadBeam cmd be hdl m
-              => BeamMigrationBackend cmd be handle m
+haskellSchema :: MonadBeam cmd be m
+              => BeamMigrationBackend cmd be m
               -> m String
 haskellSchema BeamMigrationBackend { backendGetDbConstraints = getCs
                                    , backendConvertToHaskell = HaskellPredicateConverter conv2Hs } = do

--- a/beam-postgres/Database/Beam/Postgres/Migrate.hs
+++ b/beam-postgres/Database/Beam/Postgres/Migrate.hs
@@ -69,7 +69,7 @@ import           Data.Semigroup
 #endif
 
 -- | Top-level migration backend for use by @beam-migrate@ tools
-migrationBackend :: Tool.BeamMigrationBackend PgCommandSyntax Postgres Pg.Connection Pg
+migrationBackend :: Tool.BeamMigrationBackend PgCommandSyntax Postgres Pg
 migrationBackend = Tool.BeamMigrationBackend
                         "postgres"
                         (unlines [ "For beam-postgres, this is a libpq connection string which can either be a list of key value pairs or a URI"

--- a/beam-sqlite/Database/Beam/Sqlite/Migrate.hs
+++ b/beam-sqlite/Database/Beam/Sqlite/Migrate.hs
@@ -28,8 +28,7 @@ import           Control.Applicative
 import           Control.Exception
 import           Control.Monad.Reader
 
-import           Database.SQLite.Simple
-                    ( Connection, open, close, query_ )
+import           Database.SQLite.Simple (open, close, query_)
 
 import           Data.Aeson
 import           Data.Attoparsec.Text (asciiCI, skipSpace)
@@ -48,7 +47,7 @@ import qualified Data.Text.Encoding as TE
 
 -- | Top-level 'Tool.BeamMigrationBackend' loaded dynamically by the
 -- @beam-migrate@ CLI tool.
-migrationBackend :: Tool.BeamMigrationBackend SqliteCommandSyntax Sqlite Connection SqliteM
+migrationBackend :: Tool.BeamMigrationBackend SqliteCommandSyntax Sqlite SqliteM
 migrationBackend = Tool.BeamMigrationBackend
                        "sqlite"
                        "For beam-sqlite, this is the path to a sqlite3 file"

--- a/docs/about/faq.md
+++ b/docs/about/faq.md
@@ -151,7 +151,7 @@ Suppose you had the following code to run a query over an arbitrary backend that
 supported the SQL92 syntax.
 
 ```haskell
-listEmployees :: (IsSql92Syntax cmd, MonadBeam cmd be hdl m) => m [Employee]
+listEmployees :: (IsSql92Syntax cmd, MonadBeam cmd be m) => m [Employee]
 listEmployees = runSelectReturningList $ select (all_ (employees employeeDb))
 ```
 
@@ -186,7 +186,7 @@ equalities that a sane SQL92 syntax would support. Thus the code above becomes.
 
 ```haskell
 listEmployees :: ( IsSql92Syntax cmd, Sql92SanityCheck cmd
-                 , MonadBeam cmd be hdl m)
+                 , MonadBeam cmd be m)
               => m [Employee]
 listEmployees = runSelectReturningList $ select (all_ (employees employeeDb))
 ```

--- a/docs/tutorials/tutorial1.md
+++ b/docs/tutorials/tutorial1.md
@@ -373,7 +373,7 @@ runBeamSqliteDebug putStrLn conn $ do
 Maybe we'd like something a little more interesting, such as the number of users
 for each unique first name. We can also express these aggregations using the
 `aggregate_` function. In order to get interesting results, we'll need to add
-more users to our database. We'll demonstrate using `withDatabase` to silence the debug messages.
+more users to our database.
 
 !beam-query
 ```haskell

--- a/docs/user-guide/queries/relationships.md
+++ b/docs/user-guide/queries/relationships.md
@@ -21,7 +21,7 @@ Prelude Chinook.Schema> chinook <- open "chinook.db"
 One more thing, before we explore how beam handles relationships. Before we do, let's define a quick utility function.
 
 ```haskell
-Prelude Chinook.Schema> let withConnectionTutorial = withDatabaseDebug putStrLn chinook
+Prelude Chinook.Schema> let withConnectionTutorial = runBeamSqliteDebug putStrLn chinook
 ```
 
 This function prints each of our queries to standard output before running them.

--- a/docs/user-guide/queries/select.md
+++ b/docs/user-guide/queries/select.md
@@ -24,7 +24,7 @@ One more thing, before we see more complex examples, let's define a quick
 utility function.
 
 ```haskell
-Prelude Chinook.Schema> let withConnectionTutorial = withDatabaseDebug putStrLn chinook
+Prelude Chinook.Schema> let withConnectionTutorial = runBeamSqliteDebug putStrLn chinook
 ```
 
 Let's test it!


### PR DESCRIPTION
This is a breaking change, so feel free to push back. (Although it can be made compatible at the expense of a bit of cleanliness.)

My concrete motivation for splitting these is that I want to be able to define `MonadBeam` instances to run Beam queries in other SQL libraries in order to ease the conversion of an application to Beam. In this context, `withDatabase` doesn't always make sense (especially returning raw `IO`).

More abstractly, I don't think it makes sense to group the constructors/methods of a monad class with its elimination functions. (Consider in `mtl` the elimination functions don't belong to classes at all.)

If you think this approach is worth considering, we should probably also think about the interface to `MonadWithDatabase` (name also subject to debate). I think really it should be parametrized by two monads, with the idea that you can interpret one into the other given an appropriate handle. Hard-coding `IO` won't work if you want to use transformers for example.