### PR TITLE
Fix beam postgres 0.7

### DIFF
--- a/beam-core/Database/Beam/Query/Ord.hs
+++ b/beam-core/Database/Beam/Query/Ord.hs
@@ -57,6 +57,7 @@ import Data.Proxy
 import Data.Kind
 import Data.Word
 import Data.Int
+import Data.Tagged
 import Data.Text (Text)
 import Data.Time (UTCTime, LocalTime, Day, TimeOfDay)
 
@@ -386,6 +387,8 @@ instance HasSqlEqualityCheck Expression UTCTime
 instance HasSqlEqualityCheck Expression LocalTime
 instance HasSqlEqualityCheck Expression Day
 instance HasSqlEqualityCheck Expression TimeOfDay
+instance HasSqlEqualityCheck Expression a =>
+  HasSqlEqualityCheck Expression (Tagged t a)
 
 instance HasSqlQuantifiedEqualityCheck Expression Text
 instance HasSqlQuantifiedEqualityCheck Expression Integer
@@ -406,6 +409,8 @@ instance HasSqlQuantifiedEqualityCheck Expression UTCTime
 instance HasSqlQuantifiedEqualityCheck Expression LocalTime
 instance HasSqlQuantifiedEqualityCheck Expression Day
 instance HasSqlQuantifiedEqualityCheck Expression TimeOfDay
+instance HasSqlQuantifiedEqualityCheck Expression a =>
+  HasSqlQuantifiedEqualityCheck Expression (Tagged t a)
 
 instance HasSqlEqualityCheck SqlSyntaxBuilder Text
 instance HasSqlEqualityCheck SqlSyntaxBuilder Integer
@@ -426,6 +431,8 @@ instance HasSqlEqualityCheck SqlSyntaxBuilder UTCTime
 instance HasSqlEqualityCheck SqlSyntaxBuilder LocalTime
 instance HasSqlEqualityCheck SqlSyntaxBuilder Day
 instance HasSqlEqualityCheck SqlSyntaxBuilder TimeOfDay
+instance HasSqlEqualityCheck SqlSyntaxBuilder a =>
+  HasSqlEqualityCheck SqlSyntaxBuilder (Tagged t a)
 
 instance HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder Text
 instance HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder Integer
@@ -446,3 +453,5 @@ instance HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder UTCTime
 instance HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder LocalTime
 instance HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder Day
 instance HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder TimeOfDay
+instance HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder a =>
+  HasSqlQuantifiedEqualityCheck SqlSyntaxBuilder (Tagged t a)

--- a/beam-postgres/Database/Beam/Postgres.hs
+++ b/beam-postgres/Database/Beam/Postgres.hs
@@ -48,6 +48,8 @@ module Database.Beam.Postgres
 
   , module Database.Beam.Postgres.PgSpecific
 
+  , runBeamPostgres, runBeamPostgresDebug
+
     -- ** Postgres extension support
   , PgExtensionEntity, IsPgExtension(..)
   , pgCreateExtension, pgDropExtension

--- a/beam-postgres/Database/Beam/Postgres/Syntax.hs
+++ b/beam-postgres/Database/Beam/Postgres/Syntax.hs
@@ -110,6 +110,7 @@ import           Data.Int
 import           Data.Maybe
 import           Data.Scientific (Scientific)
 import           Data.String (IsString(..), fromString)
+import           Data.Tagged
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Lazy as TL
@@ -1377,3 +1378,8 @@ PG_HAS_EQUALITY_CHECK(BL.ByteString)
 PG_HAS_EQUALITY_CHECK(V.Vector a)
 PG_HAS_EQUALITY_CHECK(CI T.Text)
 PG_HAS_EQUALITY_CHECK(CI TL.Text)
+
+instance HasSqlEqualityCheck PgExpressionSyntax a =>
+  HasSqlEqualityCheck PgExpressionSyntax (Tagged t a)
+instance HasSqlQuantifiedEqualityCheck PgExpressionSyntax a =>
+  HasSqlQuantifiedEqualityCheck PgExpressionSyntax (Tagged t a)

--- a/beam-postgres/beam-postgres.cabal
+++ b/beam-postgres/beam-postgres.cabal
@@ -50,6 +50,7 @@ library
                       vector               >=0.11 && <0.13,
                       network-uri          >=2.6  && <2.7,
                       unordered-containers >= 0.2 && <0.3,
+                      tagged               >=0.8  && <0.9,
 
                       haskell-src-exts     >=1.18 && <1.21
   default-language:   Haskell2010


### PR DESCRIPTION
Exports the Postgres run* functions and adds Tagged type instances for the new equality bits.

Closes #215