### PR TITLE
Add beam-migrate package for the tutorial

### DIFF
--- a/docs/tutorials/tutorial1.md
+++ b/docs/tutorials/tutorial1.md
@@ -15,7 +15,7 @@ here (found in the `beam-sqlite` package). Now, open up a GHCi prompt for us to
 use. Make sure to get the `beam-core` and `beam-sqlite` packages.
 
 ```console
-$ stack repl --package beam-core --package beam-sqlite --package sqlite-simple
+$ stack repl --package beam-core --package beam-sqlite --package sqlite-simple --package beam-migrate
 ```
 
 This will put you into a GHCi prompt with the `beam-core` and `beam-sqlite`


### PR DESCRIPTION
The command:

```
$ stack repl --package beam-core --package beam-sqlite --package sqlite-simple
```

from the tutorial gives the following error:

```
⋊> ~ stack repl --package beam-core --package beam-sqlite --package sqlite-simple                                                                                       14:38:15

Error: While constructing the build plan, the following exceptions were encountered:

In the dependencies for beam-sqlite-0.3.2.0:
    beam-migrate must match >=0.3 && <0.4, but the stack configuration has no specified version  (latest matching version is 0.3.1.0)
needed since beam-sqlite is a build target.

Some different approaches to resolving this:

  * Consider trying 'stack solver', which uses the cabal-install solver to attempt to find some working build configuration. This can be convenient when dealing with many
    complicated constraint errors, but results may be unpredictable.

  * Recommended action: try adding the following to your extra-deps in /Users/maximiliantagher/.stack/global-project/stack.yaml:

- beam-migrate-0.3.1.0


Error: Plan construction failed.

Warning: Build failed, but trying to launch GHCi anyway

Note: No local targets specified, so a plain ghci will be started with no package hiding or package options.

      If you want to use package hiding and options, then you can try one of the following:

      * If you want to start a different project configuration than /Users/maximiliantagher/.stack/global-project/stack.yaml, then you can use stack init to create a new
        stack.yaml for the packages in the current directory.

      * If you want to use the project configuration at /Users/maximiliantagher/.stack/global-project/stack.yaml, then you can add to its 'packages' field.

Configuring GHCi with the following packages:
GHCi, version 8.0.2: http://www.haskell.org/ghc/  :? for help
<command line>: cannot satisfy -package beam-sqlite
    (use -v for more information)
```

Adding the beam-migrate package as suggested by stack fixes the issue.

I'm using stack Version 1.7.0, Git revision 979e61339c662ed9e85cc751a66204d29bbd2bec x86_64 hpack-0.28.2, on MacOS High Sierra