### PR TITLE
Fix default SQL type for Double

### DIFF
--- a/beam-migrate/Database/Beam/Migrate/Generics/Tables.hs
+++ b/beam-migrate/Database/Beam/Migrate/Generics/Tables.hs
@@ -181,7 +181,7 @@ instance IsSql92DataTypeSyntax dataTypeSyntax => HasDefaultSqlDataType dataTypeS
 instance IsSql92ColumnSchemaSyntax columnSchemaSyntax => HasDefaultSqlDataTypeConstraints columnSchemaSyntax SqlBitString
 
 instance IsSql92DataTypeSyntax dataTypeSyntax => HasDefaultSqlDataType dataTypeSyntax Double where
-  defaultSqlDataType _ _ = realType
+  defaultSqlDataType _ _ = doubleType
 instance IsSql92ColumnSchemaSyntax columnSchemaSyntax => HasDefaultSqlDataTypeConstraints columnSchemaSyntax Double
 instance IsSql92DataTypeSyntax dataTypeSyntax => HasDefaultSqlDataType dataTypeSyntax Scientific where
   defaultSqlDataType _ _ = numericType (Just (20, Just 10))


### PR DESCRIPTION
Got some unexpected failed predicates from `verifySchema` where beam would insist it wants `Double` to be stored as `real`. [Docs](https://www.postgresql.org/docs/current/static/datatype-numeric.html) suggest this should be `double precision`.

Not quite sure how much breakage this could cause so just throwing it out here for now.