### PR TITLE
Ignore dropped columns in getDbConstraints

### DIFF
--- a/beam-postgres/Database/Beam/Postgres/Migrate.hs
+++ b/beam-postgres/Database/Beam/Postgres/Migrate.hs
@@ -276,7 +276,7 @@ getDbConstraints conn =
 
      columnChecks <-
        fmap mconcat . forM tbls $ \(oid, tbl) ->
-       do columns <- Pg.query conn "SELECT attname, atttypid, atttypmod, attnotnull, pg_catalog.format_type(atttypid, atttypmod) FROM pg_catalog.pg_attribute att WHERE att.attrelid=? AND att.attnum>0"
+       do columns <- Pg.query conn "SELECT attname, atttypid, atttypmod, attnotnull, pg_catalog.format_type(atttypid, atttypmod) FROM pg_catalog.pg_attribute att WHERE att.attrelid=? AND att.attnum>0 AND att.attisdropped='f'"
                        (Pg.Only (oid :: Pg.Oid))
           let columnChecks = map (\(nm, typId :: Pg.Oid, typmod, _, typ :: ByteString) ->
                                     let typmod' = if typmod == -1 then Nothing else Just (typmod - 4)


### PR DESCRIPTION
`getDbConstraints` must filter out dropped columns when gathering info for column checks. Otherwise the query could result in something like below. Tested on 9.6.8.

```
           attname            | atttypid | atttypmod | attnotnull |         format_type
------------------------------+----------+-----------+------------+-----------------------------
 id                           |       20 |        -1 | t          | bigint
 (...)
 ........pg.dropped.7........ |        0 |        -1 | f          | -
 ........pg.dropped.8........ |        0 |        -1 | f          | -
 ........pg.dropped.9........ |        0 |        -1 | f          | -
```