### PR TITLE
More GHC 8.4 compatibility.

### DIFF
--- a/beam-postgres/Database/Beam/Postgres/Full.hs
+++ b/beam-postgres/Database/Beam/Postgres/Full.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 -- | Module providing (almost) full support for Postgres query and data
 -- manipulation statements. These functions shadow the functions in
@@ -62,10 +63,8 @@ import           Data.Semigroup
 -- | An explicit lock against some tables. You can create a value of this type using the 'locked_'
 -- function. You can combine these values monoidally to combine multiple locks for use with the
 -- 'withLocks_' function.
-newtype PgLockedTables s = PgLockedTables [ T.Text ]
-instance Monoid (PgLockedTables s) where
-  mempty = PgLockedTables []
-  mappend (PgLockedTables a) (PgLockedTables b) = PgLockedTables (a <> b)
+newtype PgLockedTables_ s a = PgLockedTables a deriving (Semigroup, Monoid)
+type PgLockedTables s = PgLockedTables_ s [ T.Text ]
 
 -- | Combines the result of a query along with a set of locked tables. Used as a
 -- return value for the 'lockingFor_' function.

--- a/beam-postgres/Database/Beam/Postgres/Full.hs
+++ b/beam-postgres/Database/Beam/Postgres/Full.hs
@@ -63,8 +63,8 @@ import           Data.Semigroup
 -- | An explicit lock against some tables. You can create a value of this type using the 'locked_'
 -- function. You can combine these values monoidally to combine multiple locks for use with the
 -- 'withLocks_' function.
-newtype PgLockedTables_ s a = PgLockedTables a deriving (Semigroup, Monoid)
-type PgLockedTables s = PgLockedTables_ s [ T.Text ]
+newtype PgLockedTables s = PgLockedTables [ T.Text ]
+  deriving (Semigroup, Monoid)
 
 -- | Combines the result of a query along with a set of locked tables. Used as a
 -- return value for the 'lockingFor_' function.

--- a/beam-postgres/Database/Beam/Postgres/Migrate.hs
+++ b/beam-postgres/Database/Beam/Postgres/Migrate.hs
@@ -57,7 +57,6 @@ import           Data.Maybe
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Lazy.Char8 as BCL
-import           Data.Monoid (Endo(..))
 import           Data.String
 import           Data.Int
 import qualified Data.Text as T
@@ -67,6 +66,8 @@ import           Data.UUID.Types (UUID)
 import           Data.Typeable
 #if !MIN_VERSION_base(4, 11, 0)
 import           Data.Semigroup
+#else
+import           Data.Monoid (Endo(..))
 #endif
 
 -- | Top-level migration backend for use by @beam-migrate@ tools

--- a/beam-postgres/Database/Beam/Postgres/Migrate.hs
+++ b/beam-postgres/Database/Beam/Postgres/Migrate.hs
@@ -57,6 +57,7 @@ import           Data.Maybe
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Lazy.Char8 as BCL
+import           Data.Monoid (Endo(..))
 import           Data.String
 import           Data.Int
 import qualified Data.Text as T

--- a/beam-postgres/Database/Beam/Postgres/Syntax.hs
+++ b/beam-postgres/Database/Beam/Postgres/Syntax.hs
@@ -178,11 +178,11 @@ newtype PgSyntax
   = PgSyntax { buildPgSyntax :: PgSyntaxM () }
 
 instance Semigroup PgSyntax where
-  (<>) = mappend
+  a <> b = PgSyntax (buildPgSyntax a >> buildPgSyntax b)
 
 instance Monoid PgSyntax where
   mempty = PgSyntax (pure ())
-  mappend a b = PgSyntax (buildPgSyntax a >> buildPgSyntax b)
+  mappend = (<>)
 
 instance Eq PgSyntax where
   PgSyntax x == PgSyntax y = (fromF x :: Free PgSyntaxF ()) == fromF y


### PR DESCRIPTION
The build of `beam-postgres` failed for me with GHC 8.4.2 because of Semigroup/Monoid issues.  What do you think of this approach, using newtype deriving with an intermediate type?  With these changes I'm able to build and install.