### PR TITLE
Postgres Range type support

### DIFF
--- a/beam-postgres/Database/Beam/Postgres.hs
+++ b/beam-postgres/Database/Beam/Postgres.hs
@@ -7,7 +7,7 @@
 --
 -- @beam-postgres@ supports most beam features as well as many postgres-specific
 -- features. For example, @beam-postgres@ provides support for full-text search,
--- @DISTINCT ON@, JSON handling, postgres @ARRAY@s, and the @MONEY@ type.
+-- @DISTINCT ON@, JSON handling, postgres @ARRAY@s, @RANGE@s, and the @MONEY@ type.
 --
 -- The documentation for @beam-postgres@ functionality below indicates which
 -- postgres function each function or type wraps. Postgres maintains its own

--- a/beam-postgres/Database/Beam/Postgres/PgSpecific.hs
+++ b/beam-postgres/Database/Beam/Postgres/PgSpecific.hs
@@ -455,7 +455,7 @@ unbounded = PgRangeBound Exclusive Nothing
 --
 -- A reasonable example might be @Range PgInt8Range Int64@.
 -- This represents a range of Haskell @Int64@ values stored as a range of 'bigint' in Postgres.
-data PgRange n a
+data PgRange (n :: *) a
   = PgEmptyRange
   | PgRange (PgRangeBound a) (PgRangeBound a)
   deriving (Show, Generic)

--- a/beam-postgres/Database/Beam/Postgres/PgSpecific.hs
+++ b/beam-postgres/Database/Beam/Postgres/PgSpecific.hs
@@ -83,7 +83,7 @@ module Database.Beam.Postgres.PgSpecific
   , range_
   
     -- *** Building @PgRangeBound@s
-  , inclusive, exclusive
+  , inclusive, exclusive, unbounded
 
     -- *** Range operators and functions
   , (-@>-), (-@>), (-<@-), (<@-)
@@ -441,11 +441,14 @@ uBound Exclusive = ")"
 -- (the absense of a value represents unbounded).
 data PgRangeBound a = PgRangeBound PgBoundType (Maybe a) deriving (Show, Generic)
 
-inclusive :: Maybe a -> PgRangeBound a
-inclusive = PgRangeBound Inclusive
+inclusive :: a -> PgRangeBound a
+inclusive = PgRangeBound Inclusive . Just
 
-exclusive :: Maybe a -> PgRangeBound a
-exclusive = PgRangeBound Exclusive
+exclusive :: a -> PgRangeBound a
+exclusive = PgRangeBound Exclusive . Just
+
+unbounded :: PgRangeBound a
+unbounded = PgRangeBound Exclusive Nothing
 
 -- | A range of a given Haskell type (represented by @a@) stored as a given Postgres Range Type
 -- (represented by @n@).


### PR DESCRIPTION
I noticed this appeared missing from the Postgres specific package.

I admittedly haven't tested this locally (yet) so there could be syntax bugs, missing constraints, etc. but I figured I'd gone far enough without some feedback (maybe too far?).

I'm also pretty sure this doesn't support beam-migrate yet. I'm not familiar with that functionality at all but I'd be willing to add that support to this PR with a bit of guidance.

When you get a chance, let me know what you think of the general design or any questions/comments you have.

Next chance I get to work on this I'll confirm some basic schema definitions and queries, assuming you don't have any fundamental design change requests to take care of first.