### PR TITLE
Tutorial 1 fixes

### DIFF
--- a/docs/tutorials/tutorial1.md
+++ b/docs/tutorials/tutorial1.md
@@ -111,7 +111,7 @@ values of type `User`. We can use the `StandaloneDeriving` and
 'regular' datatype.
 
 ```
-> :set -XStandaloneDeriving -XTypeSynonymInstances
+> :set -XStandaloneDeriving -XTypeSynonymInstances -XMultiParamTypeClasses
 ```
 
 Now we can derive `Show` and `Eq` instances.

--- a/docs/tutorials/tutorial1.md
+++ b/docs/tutorials/tutorial1.md
@@ -12,10 +12,10 @@ To start defining beam schemas and queries, you only need to import the
 `Database.Beam` module. To interface with an actual database, you'll need to
 import one of the database backends. We'll see how to use the Sqlite backend
 here (found in the `beam-sqlite` package). Now, open up a GHCi prompt for us to
-use. Make sure to get the `beam-core` and `beam-sqlite` packages.
+use. Make sure to get the `beam-core`, `beam-sqlite` and `text` packages.
 
 ```console
-$ stack repl --package beam-core --package beam-sqlite --package sqlite-simple --package beam-migrate
+$ stack repl --package beam-core --package beam-sqlite --package sqlite-simple --package beam-migrate --package text
 ```
 
 This will put you into a GHCi prompt with the `beam-core` and `beam-sqlite`


### PR DESCRIPTION
I fixed some small errors when going through the first tutorial.

Adding `MultiParamTypeClasses` in GHCI is only necessary when following the tutorial in GHCI past the "Defining our database" headline. However, I doubt anyone is still using GHCI at this point, because you can't c&p multiline definitions into GHCI, so many will probably already give up when trying to define `UserT` (at least I did).

Maybe it would be easier to follow when telling people to create a file (`Main.hs`) and load that into GHCI (`:l Main` / `:r` + functions `insertUsers`, `query1`, ...)?