### PR TITLE
Adds instances for UTCTime in the Postgres backend

### DIFF
--- a/beam-postgres/Database/Beam/Postgres/Syntax.hs
+++ b/beam-postgres/Database/Beam/Postgres/Syntax.hs
@@ -1328,6 +1328,10 @@ instance HasDefaultSqlDataType PgDataTypeSyntax LocalTime where
   defaultSqlDataType _ _ = timestampType Nothing False
 instance HasDefaultSqlDataTypeConstraints PgColumnSchemaSyntax LocalTime
 
+instance HasDefaultSqlDataType PgDataTypeSyntax UTCTime where
+  defaultSqlDataType _ _ = timestampType Nothing False
+instance HasDefaultSqlDataTypeConstraints PgColumnSchemaSyntax UTCTime
+
 instance HasDefaultSqlDataType PgDataTypeSyntax (SqlSerial Int) where
   defaultSqlDataType _ False = pgSerialType
   defaultSqlDataType _ _ = intType


### PR DESCRIPTION
Assumes that the instance defintions for LocalTime should be OK for UTCTime,
although perhaps the LocalTime HasSqlDataType definition ought to be changed to

```haskell
    defaultSqlDataType _ _ timestampTyep Nothing True
```

since LocalTime is expected to reflect the timezone of the database ?

Fixes #282 