### PR TITLE
Add '<|>.' operator

### DIFF
--- a/beam-core/Database/Beam/Query/Combinators.hs
+++ b/beam-core/Database/Beam/Query/Combinators.hs
@@ -902,7 +902,9 @@ instance ( IsSql92ExpressionSyntax syntax
       in QExpr (\tblPfx -> caseE [(cond tblPfx, onJust' tblPfx)] (onNothing tblPfx))
 
 infixl 3 <|>.
-(<|>.) :: (SqlJustable a (QExpr syntax s y), SqlDeconstructMaybe syntax (QExpr syntax s y) a s)
+(<|>.) :: ( y ~ Maybe a
+          , SqlJustable a (QExpr syntax s y)
+          )
        => QExpr syntax s y
        -> QExpr syntax s y
        -> QExpr syntax s y

--- a/beam-core/Database/Beam/Query/Combinators.hs
+++ b/beam-core/Database/Beam/Query/Combinators.hs
@@ -36,6 +36,7 @@ module Database.Beam.Query.Combinators
     , SqlDeconstructMaybe(..)
     , SqlOrderable
     , QIfCond, QIfElse
+    , (<|>.)
 
     , limit_, offset_
 
@@ -899,3 +900,10 @@ instance ( IsSql92ExpressionSyntax syntax
       let QExpr onJust' = onJust (changeBeamRep (\(Columnar' (QExpr e)) -> Columnar' (QExpr e)) tbl)
           QExpr cond = isJust_ tbl
       in QExpr (\tblPfx -> caseE [(cond tblPfx, onJust' tblPfx)] (onNothing tblPfx))
+
+infixl 3 <|>.
+(<|>.) :: (SqlJustable a (QExpr syntax s y), SqlDeconstructMaybe syntax (QExpr syntax s y) a s)
+       => QExpr syntax s y
+       -> QExpr syntax s y
+       -> QExpr syntax s y
+l <|>. r = maybe_ r just_ l


### PR DESCRIPTION
I've been using this as a `<|>` equivalent (specialized to `Maybe`) for "get the first non-null" behavior.

`ghci` actually inferred a more general type, but I'm not familiar enough with Beam to tell which is a better fit:
```haskell
(SqlJustable a2 (QGenExpr ctxt syntax s y), SqlDeconstructMaybe syntax a1 a2 s) =>
  a1 -> QGenExpr ctxt syntax s y -> QGenExpr ctxt syntax s y
```