### PR TITLE
Pg array improvements

### DIFF
--- a/beam-postgres/Database/Beam/Postgres/PgSpecific.hs
+++ b/beam-postgres/Database/Beam/Postgres/PgSpecific.hs
@@ -403,7 +403,7 @@ instance PgIsArrayContext QWindowingContext
 -- containing expressions.
 array_ :: forall context f s a.
           (PgIsArrayContext context, Foldable f)
-       => f (QGenExpr PgArrayValueContext PgExpressionSyntax s a)
+       => f (QGenExpr context PgExpressionSyntax s a)
        -> QGenExpr context PgExpressionSyntax s (V.Vector a)
 array_ vs =
   QExpr $ fmap (PgExpressionSyntax . mkArraySyntax (Proxy @context) . mconcat) $

--- a/beam-postgres/Database/Beam/Postgres/Syntax.hs
+++ b/beam-postgres/Database/Beam/Postgres/Syntax.hs
@@ -1146,6 +1146,9 @@ instance HasSqlValueSyntax PgValueSyntax B.ByteString where
 instance HasSqlValueSyntax PgValueSyntax BL.ByteString where
   sqlValueSyntax = defaultPgValueSyntax . Pg.Binary
 
+instance Pg.ToField a => HasSqlValueSyntax PgValueSyntax (V.Vector a) where
+  sqlValueSyntax = defaultPgValueSyntax
+
 pgQuotedIdentifier :: T.Text -> PgSyntax
 pgQuotedIdentifier t =
   escapeIdentifier (TE.encodeUtf8 t)

--- a/beam-postgres/Database/Beam/Postgres/Syntax.hs
+++ b/beam-postgres/Database/Beam/Postgres/Syntax.hs
@@ -52,6 +52,7 @@ module Database.Beam.Postgres.Syntax
     , PgSelectLockingOptions(..)
     , fromPgSelectLockingClause
     , pgSelectStmt
+    , defaultPgValueSyntax
 
     , PgDataTypeDescr(..)
 


### PR DESCRIPTION
When attempting to use `array_` I found myself unable to get it to type check. The problem appeared to be the hard requirement of `PgArrayValueContext` for the expressions in the `Foldable`. Looking through the docs, it appears to be impossible to construct a value/expression with this context. On the other hand, `PgIsArrayContext :: Constraint` seems to already limit `context` to the appropriate contexts (Value, Aggregate, Window).

 I think the change below is correct as it limits possible contexts to those that can exist in an array and makes `array_` keeps the context of the subexpression.

The `Vector` `HasValueSyntax` instance needed to reference array literals appeared to be missing.

I exported `defaultPgValueSyntax` as this was the first thing I attempted to reach for to define a temporary orphan instance. I believe this would help users who define custom types.

I've tested that all of these changes locally, they type check and generate valid queries.

Let me know if you have issues with some of these changes and I can revert the offending commits.