### PR TITLE
Fix createTable when there is no Primary Key

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -13,3 +13,5 @@ Beam would like to thank the following people for their contributions to beam.
 "Sam Protas"<sam.protas@gmail.com>
 "Alejandro Duran Pallares"<vwwv@correo.ugr.es>
 "Felix Scheinost" <felix.scheinost@posteo.de>
+"Kostas Dermentzis"<k.dermenz@gmail.com>
+

--- a/beam-migrate/Database/Beam/Migrate/SQL/Tables.hs
+++ b/beam-migrate/Database/Beam/Migrate/SQL/Tables.hs
@@ -76,11 +76,12 @@ createTable :: ( Beamable table, Table table
                Text -> TableSchema (Sql92CreateTableColumnSchemaSyntax (Sql92DdlCommandCreateTableSyntax syntax)) table
             -> Migration syntax (CheckedDatabaseEntity be db (TableEntity table))
 createTable newTblName tblSettings =
-  do let createTableCommand =
+  do let pkFields = allBeamValues (\(Columnar' (TableFieldSchema name _ _)) -> name) (primaryKey tblSettings)
+         tblConstraints = if null pkFields then [] else [ primaryKeyConstraintSyntax pkFields ]
+         createTableCommand =
            createTableSyntax Nothing newTblName
                              (allBeamValues (\(Columnar' (TableFieldSchema name (FieldSchema schema) _)) -> (name, schema)) tblSettings)
-                             [ primaryKeyConstraintSyntax (allBeamValues (\(Columnar' (TableFieldSchema name _ _)) -> name) (primaryKey tblSettings)) ]
-
+                             tblConstraints
          command = createTableCmd createTableCommand
 
          tbl' = changeBeamRep (\(Columnar' (TableFieldSchema name _ _)) -> Columnar' (TableField name)) tblSettings


### PR DESCRIPTION
While running this simplified example
```
data UserDB f = UserDB {
    _uDbUser  :: f (TableEntity UserT)
    } deriving Generic
data UserT f = User { _uName :: Columnar f String
                    , _uAge  :: Columnar f Word32
                    } deriving Generic
instance Beamable UserT
instance Table UserT where
    data PrimaryKey UserT f = UserPrimKey deriving Generic
    primaryKey User{..} = UserPrimKey
instance Database Sqlite UserDB
instance Beamable (PrimaryKey UserT)

testSQlite :: IO ()
testSQlite = do
    conn <- Sqlite.open ":memory:"
    runBeamSqliteDebug putStrLn conn $
        executeMigration runNoReturn initialMigration
    Sqlite.close conn

initialMigration =
    UserDB <$> createTable "users"
                (User (field "name" (DataType (varCharType Nothing Nothing)) notNull)
                        (field "age" (DataType intType) notNull)
                )
```
I noticed a runtime error 
``` 
CREATE TABLE "users"("name" VARCHAR NOT NULL , "age" INTEGER NOT NULL , PRIMARY KEY());
-- With values: []
tx: SQLite3 returned ErrorError while attempting to perform prepare "CREATE TABLE \"users\"(\"name\" VARCHAR NOT NULL , \"age\" INTEGER NOT NULL , PRIMARY KEY())": near ")": syntax error 
```
It looks like SQlite does not accept empty Primary Key list https://www.sqlite.org/syntax/table-constraint.html. 
This PR makes `PRIMARY KEY` to only appear if the column list is non-empty.

The solution is polymorphic, since this is the case also for postgres https://www.postgresql.org/docs/9.1/static/sql-createtable.html. If we replace with
```
testPostGres = do
    conn <- PostgreSQL.connect PostgreSQL.defaultConnectInfo
    runBeamPostgresDebug putStrLn conn $
        executeMigration runNoReturn initialMigration
    PostgreSQL.close conn
```
there is a similar error:
```
CREATE TABLE "users" ("name" VARCHAR NOT NULL, "age" INT NOT NULL, PRIMARY KEY()) 
tx: SqlError {sqlState = "42601", sqlExecStatus = FatalError, sqlErrorMsg = "syntax error at or near \")\"", sqlErrorDetail = "", sqlErrorHint = ""}
```

The corrected syntax is for SQlite:
```
CREATE TABLE "users"("name" VARCHAR NOT NULL , "age" INTEGER NOT NULL );
-- With values: []
```
and for PostGres:
```
CREATE TABLE "users" ("name" VARCHAR NOT NULL, "age" INT NOT NULL)
```