### PR TITLE
Add SQLite group_concat function

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,3 +12,4 @@ Beam would like to thank the following people for their contributions to beam.
 "Brian Jones"<brian@uncannyworks.com>
 "Sam Protas"<sam.protas@gmail.com>
 "Alejandro Duran Pallares"<vwwv@correo.ugr.es>
+"Felix Scheinost" <felix.scheinost@posteo.de>

--- a/beam-sqlite/Database/Beam/Sqlite.hs
+++ b/beam-sqlite/Database/Beam/Sqlite.hs
@@ -9,8 +9,11 @@ module Database.Beam.Sqlite
   , SqliteUpdateSyntax, SqliteDeleteSyntax
 
   , fromSqliteCommand, sqliteRenderSyntaxScript
+
+  ,  module Database.Beam.Sqlite.SqliteSpecific
   ) where
 
 import Database.Beam.Sqlite.Syntax
+import Database.Beam.Sqlite.SqliteSpecific
 import Database.Beam.Sqlite.Connection
 import Database.Beam.Sqlite.Migrate (sqliteText, sqliteBlob, sqliteBigInt)

--- a/beam-sqlite/Database/Beam/Sqlite/SqliteSpecific.hs
+++ b/beam-sqlite/Database/Beam/Sqlite/SqliteSpecific.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Postgres-specific types, functions, and operators
+module Database.Beam.Sqlite.SqliteSpecific
+    ( -- * Sqlite functions and aggregates
+      sqliteGroupConcat
+    , sqliteGroupConcatOver
+    )
+where
+
+import           Database.Beam
+import           Database.Beam.Backend.SQL
+import           Database.Beam.Query.Internal
+import           Database.Beam.Sqlite.Syntax
+#if !MIN_VERSION_base(4, 11, 0)
+import           Data.Semigroup
+#endif
+
+-- | The SQLite @group_concat@ function.
+-- Joins the value in each row of the first argument, using the second
+-- argument as a delimiter. See 'sqliteGroupConcatOver' if you want to provide
+-- explicit quantification.
+sqliteGroupConcat 
+    :: ( HasSqlValueSyntax SqliteValueSyntax a
+       , IsSqlExpressionSyntaxStringType SqliteExpressionSyntax str 
+       , IsSqlExpressionSyntaxStringType SqliteExpressionSyntax str2
+       )
+    => QExpr SqliteExpressionSyntax s a
+    -> QExpr SqliteExpressionSyntax s str
+    -> QAgg SqliteExpressionSyntax s (Maybe str2)
+sqliteGroupConcat v delim = _sqliteGroupConcatOver allInGroup_ v (Just delim)
+
+
+-- | The SQLite @group_concat@ function.
+-- Joins the value in each row of the first argument using ','.
+-- See 'sqliteGroupConcat' if you want to change the delimiter.
+-- Choosing a custom delimiter and quantification isn't allowed by SQLite.
+sqliteGroupConcatOver 
+    :: ( HasSqlValueSyntax SqliteValueSyntax a
+        , IsSqlExpressionSyntaxStringType SqliteExpressionSyntax str 
+        )
+    => Maybe SqliteAggregationSetQuantifierSyntax
+    -> QExpr SqliteExpressionSyntax s a
+    -> QAgg SqliteExpressionSyntax s (Maybe str)
+sqliteGroupConcatOver quantifier v = _sqliteGroupConcatOver quantifier v Nothing
+
+-- SQLite doesn't allow DISTINCT and a custom delimiter
+_sqliteGroupConcatOver 
+    :: ( HasSqlValueSyntax SqliteValueSyntax a
+        , IsSqlExpressionSyntaxStringType SqliteExpressionSyntax str
+        )
+    => Maybe SqliteAggregationSetQuantifierSyntax
+    -> QExpr SqliteExpressionSyntax s a
+    -> Maybe (QExpr SqliteExpressionSyntax s str2)
+    -> QAgg SqliteExpressionSyntax s (Maybe str)
+_sqliteGroupConcatOver quantifier (QExpr v) delim =
+    QExpr $ \tbl -> SqliteExpressionSyntax $
+    emit "group_concat" <>
+    parens ( maybe mempty (\q -> fromSqliteAggregationSetQuantifier q <> emit " ") quantifier <>
+             fromSqliteExpression (v tbl) <> 
+             maybe mempty (\(QExpr d) -> emit ", " <> fromSqliteExpression (d tbl)) delim)

--- a/beam-sqlite/Database/Beam/Sqlite/Syntax.hs
+++ b/beam-sqlite/Database/Beam/Sqlite/Syntax.hs
@@ -21,6 +21,9 @@ module Database.Beam.Sqlite.Syntax
   , SqliteInsertValuesSyntax(..)
   , SqliteColumnSchemaSyntax(..)
   , SqliteExpressionSyntax(..), SqliteValueSyntax(..)
+  , SqliteAggregationSetQuantifierSyntax(..)
+
+  , fromSqliteExpression
 
     -- * SQLite data type syntax
   , SqliteDataTypeSyntax(..)
@@ -30,7 +33,7 @@ module Database.Beam.Sqlite.Syntax
     -- * Building and consuming 'SqliteSyntax'
   , fromSqliteCommand, formatSqliteInsert
 
-  , emit, emitValue
+  , emit, emitValue, parens
 
   , sqliteEscape, withPlaceholders
   , sqliteRenderSyntaxScript

--- a/beam-sqlite/beam-sqlite.cabal
+++ b/beam-sqlite/beam-sqlite.cabal
@@ -23,6 +23,7 @@ library
                       Database.Beam.Sqlite.Syntax
                       Database.Beam.Sqlite.Connection
                       Database.Beam.Sqlite.Migrate
+  other-modules:      Database.Beam.Sqlite.SqliteSpecific
   build-depends:      base          >=4.7  && <5,
 
                       beam-core     >=0.7  && <0.8,


### PR DESCRIPTION
Add the SQLite [group_concat](https://www.sqlite.org/lang_aggfunc.html#groupconcat) function.

I pretty much just copied the [implemention](https://github.com/tathougies/beam/blob/d6b45713de886e7cfbd019eafb86496cc99182dc/beam-postgres/Database/Beam/Postgres/PgSpecific.hs#L1061) of the PG `string_agg` function.

Differences to `pgStringAgg` 

1. Input constraint changed from `IsSqlExpressionSyntaxStringType` to `HasSqlValueSyntax` 

    The reason for that is simply that I need to join an `INTEGER` column in my project. I think a better solution might be to use `cast_`. I couldn't find an implementation of `cast_` though, just `caseE`. Is this a dealbreaker? I guess that e.g. joining `BLOB` really doesn't make sense. Could I constrain the function to take string and number types somehow?

2. Split into two functions beacuse SQLite won't allow `group_concat(distinct col, 'delim')`. Either set quantification or change delimiter.