### PR TITLE
Add UTCTime datatypeconstraints and datatype syntax

### DIFF
--- a/beam-postgres/Database/Beam/Postgres/Syntax.hs
+++ b/beam-postgres/Database/Beam/Postgres/Syntax.hs
@@ -1390,3 +1390,7 @@ instance HasSqlEqualityCheck PgExpressionSyntax a =>
   HasSqlEqualityCheck PgExpressionSyntax (Tagged t a)
 instance HasSqlQuantifiedEqualityCheck PgExpressionSyntax a =>
   HasSqlQuantifiedEqualityCheck PgExpressionSyntax (Tagged t a)
+
+instance HasDefaultSqlDataTypeConstraints PgColumnSchemaSyntax UTCTime
+instance HasDefaultSqlDataType PgDataTypeSyntax UTCTime where
+    defaultSqlDataType _ _ = timestampType Nothing True


### PR DESCRIPTION
I first thought this was trivial but after encountering a runtime bug with this I'd better upstream. The timezone has to be part of UTCTime otherwise it can't parse it but it does compile.