### PR TITLE
PeekField: Enable propagating backend errors

### DIFF
--- a/beam-core/Database/Beam/Backend/Types.hs
+++ b/beam-core/Database/Beam/Backend/Types.hs
@@ -15,6 +15,7 @@ module Database.Beam.Backend.Types
 
 import           Control.Monad.Free.Church
 import           Control.Monad.Identity
+import           Control.Exception (SomeException)
 import           Data.Tagged
 import           Data.Vector.Sized (Vector)
 import qualified Data.Vector.Sized as Vector
@@ -32,7 +33,7 @@ class BeamBackend be where
 
 data FromBackendRowF be f where
   ParseOneField :: BackendFromField be a => (a -> f) -> FromBackendRowF be f
-  PeekField :: BackendFromField be a => (Maybe a -> f) -> FromBackendRowF be f
+  PeekField :: BackendFromField be a => (Either [SomeException] a -> f) -> FromBackendRowF be f
   CheckNextNNull :: Int -> (Bool -> f) -> FromBackendRowF be f
 deriving instance Functor (FromBackendRowF be)
 type FromBackendRowM be = F (FromBackendRowF be)
@@ -40,7 +41,7 @@ type FromBackendRowM be = F (FromBackendRowF be)
 parseOneField :: BackendFromField be a => FromBackendRowM be a
 parseOneField = liftF (ParseOneField id)
 
-peekField :: BackendFromField be a => FromBackendRowM be (Maybe a)
+peekField :: BackendFromField be a => FromBackendRowM be (Either [SomeException] a)
 peekField = liftF (PeekField id)
 
 checkNextNNull :: Int -> FromBackendRowM be Bool

--- a/beam-sqlite/Database/Beam/Sqlite/Connection.hs
+++ b/beam-sqlite/Database/Beam/Sqlite/Connection.hs
@@ -163,8 +163,8 @@ instance FromBackendRow Sqlite a => FromRow (BeamSqliteRow a) where
               ro <- ask
               st <- get
               case runStateT (runReaderT (unRP field) ro) st of
-                Ok (a, _) -> unRP (next (Just a))
-                _ -> unRP (next Nothing)
+                Ok (a, _) -> unRP (next (Right a))
+                Errors exL -> unRP (next (Left exL))
         step (CheckNextNNull n next) =
             RP $ do
               ro <- ask


### PR DESCRIPTION
Instead of PeekField containing a function that is passed
`Nothing` in case of an error, change the function's type to
`Either [SomeException] a -> f` to allow passing a description
of the error(s) to the backend library.

This allows backends to throw a more descriptive exception
e.g. in case of errors during field parsing.

This PR addresses issue #299