### PR TITLE
export modifyEntityName, modifyTableFields

### DIFF
--- a/beam-core/Database/Beam/Schema.hs
+++ b/beam-core/Database/Beam/Schema.hs
@@ -33,7 +33,7 @@ module Database.Beam.Schema
     , DatabaseModification, EntityModification, FieldModification
     , withDbModification, withTableModification
     , dbModification, tableModification
-    , modifyTable, fieldNamed
+    , modifyTable, modifyEntityName, modifyTableFields, fieldNamed
 
     -- * Types for lens generation
     , Lenses, LensFor(..)

--- a/beam-core/Database/Beam/Schema/Tables.hs
+++ b/beam-core/Database/Beam/Schema/Tables.hs
@@ -22,7 +22,7 @@ module Database.Beam.Schema.Tables
     , DatabaseModification, EntityModification(..)
     , FieldModification(..)
     , dbModification, tableModification, withDbModification
-    , withTableModification, modifyTable, modifyEntityName, fieldNamed
+    , withTableModification, modifyTable, modifyEntityName, modifyTableFields, fieldNamed
     , defaultDbSettings
 
     , RenamableWithRule(..), RenamableField(..)


### PR DESCRIPTION
ghc complains `modifyTable` is deprecated. but `Database.Beam` doesn't  export alternative functions.

```
<interactive>:1:1: warning: [-Wdeprecations]
    In the use of ‘modifyTable’
    (imported from Database.Beam, but defined in Database.Beam.Schema.Tables):
    Deprecated: "Instead of 'modifyTable fTblNm fFields', use 'modifyEntityName _ <> modifyTableFields _'"
```
