### PR TITLE
A small typo that messes up Markdown

### DIFF
--- a/docs/tutorials/tutorial3.md
+++ b/docs/tutorials/tutorial3.md
@@ -237,7 +237,8 @@ bettyShippingInfo <-
 
 If you run this, you'll get an error from GHCi.
 
-```<interactive>:845:7: error:
+```
+<interactive>:845:7: error:
     • No instance for (FromBackendRow Sqlite ShippingCarrier)
         arising from a use of ‘runInsertReturningList’
     • In a stmt of a 'do' block:


### PR DESCRIPTION
Because of this missing newline, this part currently looks like this on `github.io`:

![image](https://user-images.githubusercontent.com/4219105/60066525-6cdaf480-96d5-11e9-9872-263e820d812d.png)
