### PR TITLE
Remove out of date note about `in_` on primary keys which is now supported

### DIFF
--- a/docs/user-guide/expressions.md
+++ b/docs/user-guide/expressions.md
@@ -200,10 +200,6 @@ limit_ 10 $
   all_ (customer chinookDb)
 ```
 
-!!! note "Note"
-    If you want to filter for primary keys you have to manually unwrap them,
-    for more information see [here](https://github.com/tathougies/beam/issues/333#issuecomment-444728791).
-
 ## `CASE .. WHEN .. ELSE ..` statements
 
 The SQL `CASE .. WHEN .. ELSE` construct can be used to implement a multi-way


### PR DESCRIPTION
The note added in https://github.com/tathougies/beam/pull/361 is no longer needed as `in_` on primary keys is supported as of https://github.com/tathougies/beam/pull/384.