### PR TITLE
Split WithConstraint into versions with/without value and remove partiality

### DIFF
--- a/beam-core/Database/Beam/Query/Combinators.hs
+++ b/beam-core/Database/Beam/Query/Combinators.hs
@@ -88,8 +88,6 @@ import Data.Maybe
 import Data.Proxy
 import Data.Time (LocalTime)
 
-import GHC.Generics
-
 -- | Introduce all entries of a table into the 'Q' monad
 all_ :: ( Database be db, BeamSqlBackend be )
        => DatabaseEntity be db (TableEntity table)
@@ -545,8 +543,7 @@ instance ( Beamable table, BeamSqlBackend be
   SqlValable (table (QGenExpr ctxt be s)) where
   val_ tbl =
     let fields :: table (WithConstraint (BeamSqlBackendCanSerialize be))
-        fields = to (gWithConstrainedFields (Proxy @(BeamSqlBackendCanSerialize be))
-                                            (Proxy @(Rep (table Exposed))) (from tbl))
+        fields = withConstrainedFields tbl
     in changeBeamRep (\(Columnar' (WithConstraint x :: WithConstraint (BeamSqlBackendCanSerialize be) x)) ->
                          Columnar' (QExpr (pure (valueE (sqlValueSyntax x))))) fields
 instance ( Beamable table, BeamSqlBackend be
@@ -556,8 +553,7 @@ instance ( Beamable table, BeamSqlBackend be
 
   val_ tbl =
     let fields :: table (Nullable (WithConstraint (BeamSqlBackendCanSerialize be)))
-        fields = to (gWithConstrainedFields (Proxy @(BeamSqlBackendCanSerialize be))
-                                            (Proxy @(Rep (table (Nullable Exposed)))) (from tbl))
+        fields = withNullableConstrainedFields tbl
     in changeBeamRep (\(Columnar' (WithConstraint x :: WithConstraint (BeamSqlBackendCanSerialize be) (Maybe x))) ->
                          Columnar' (QExpr (pure (valueE (sqlValueSyntax x))))) fields
 

--- a/beam-core/Database/Beam/Query/Ord.hs
+++ b/beam-core/Database/Beam/Query/Ord.hs
@@ -305,7 +305,7 @@ instance ( BeamSqlBackend be, Beamable tbl
          SqlEq (QGenExpr context be s) (tbl (QGenExpr context be s)) where
 
   a ==. b = let (_, e) = runState (zipBeamFieldsM
-                                   (\x'@(Columnar' (Columnar' (WithConstraint _) :*: Columnar' x)) (Columnar' y) ->
+                                   (\x'@(Columnar' (Columnar' HasConstraint :*: Columnar' x)) (Columnar' y) ->
                                        do modify (\expr ->
                                                     case expr of
                                                       Nothing -> Just $ x ==. y
@@ -315,7 +315,7 @@ instance ( BeamSqlBackend be, Beamable tbl
   a /=. b = not_ (a ==. b)
 
   a ==?. b = let (_, e) = runState (zipBeamFieldsM
-                                    (\x'@(Columnar' (Columnar' (WithConstraint _) :*: Columnar' x)) (Columnar' y) ->
+                                    (\x'@(Columnar' (Columnar' HasConstraint :*: Columnar' x)) (Columnar' y) ->
                                         do modify (\expr ->
                                                      case expr of
                                                        Nothing -> Just $ x ==?. y
@@ -329,7 +329,7 @@ instance ( BeamSqlBackend be, Beamable tbl
     => SqlEq (QGenExpr context be s) (tbl (Nullable (QGenExpr context be s))) where
 
   a ==. b = let (_, e) = runState (zipBeamFieldsM
-                                      (\x'@(Columnar' (Columnar' (WithConstraint _) :*: Columnar' x)) (Columnar' y) -> do
+                                      (\x'@(Columnar' (Columnar' HasConstraint :*: Columnar' x)) (Columnar' y) -> do
                                           modify (\expr ->
                                                     case expr of
                                                       Nothing -> Just $ x ==. y
@@ -340,7 +340,7 @@ instance ( BeamSqlBackend be, Beamable tbl
   a /=. b = not_ (a ==. b)
 
   a ==?. b = let (_, e) = runState (zipBeamFieldsM
-                                    (\x'@(Columnar' (Columnar' (WithConstraint _) :*: Columnar' x)) (Columnar' y) ->
+                                    (\x'@(Columnar' (Columnar' HasConstraint :*: Columnar' x)) (Columnar' y) ->
                                         do modify (\expr ->
                                                      case expr of
                                                        Nothing -> Just $ x ==?. y


### PR DESCRIPTION
Removing this use of `undefined` seems to make it possible to use strict fields for table and database types. Splitting `WithConstraint` also improves conceptual clarity and type safety by distinguishing cases where it is used just to carry around a constraint, and cases where the constrained value is carried too.