### PR TITLE
SomeBeamMigrationBackend needs MonadFail

### DIFF
--- a/beam-migrate-cli/Database/Beam/Migrate/Tool/Migrate.hs
+++ b/beam-migrate-cli/Database/Beam/Migrate/Tool/Migrate.hs
@@ -10,6 +10,7 @@ import           Database.Beam.Migrate.Tool.Status
 import           Control.Applicative
 import           Control.Exception
 import           Control.Monad
+import qualified Control.Monad.Fail as Fail
 
 import qualified Data.ByteString.Char8 as BS
 import           Data.Char as Char
@@ -52,7 +53,8 @@ showCommands cmds = do
     yellow x = setSGRCode [ SetColor Foreground Dull Yellow ] ++ x ++ setSGRCode [ Reset ]
     green x = setSGRCode [ SetColor Foreground Dull Green ] ++ x ++ setSGRCode [ Reset ]
 
-getSchemaCommandsForBackend :: MigrationRegistry -> Maybe (BeamMigrationBackend be m)
+getSchemaCommandsForBackend :: Fail.MonadFail m
+                            => MigrationRegistry -> Maybe (BeamMigrationBackend be m)
                             -> UUID -> IO [ MigrateDDLCommand cmd ]
 getSchemaCommandsForBackend reg Nothing id = fail "Asked to get haskell schema"
 getSchemaCommandsForBackend reg (Just be@(BeamMigrationBackend {})) commitId =

--- a/beam-migrate/Database/Beam/Migrate/Backend.hs
+++ b/beam-migrate/Database/Beam/Migrate/Backend.hs
@@ -74,6 +74,7 @@ type DdlError = String
 data BeamMigrationBackend be m where
   BeamMigrationBackend ::
     ( MonadBeam be m
+    , Fail.MonadFail m -- TODO check whether this is good
     , HasQBuilder be
     , BeamMigrateSqlBackend be
     , HasDataTypeCreatedCheck (BeamMigrateSqlBackendDataTypeSyntax be)
@@ -96,10 +97,7 @@ data BeamMigrationBackend be m where
 -- | Monomorphic wrapper for use with plugin loaders that cannot handle
 -- polymorphism
 data SomeBeamMigrationBackend where
-  SomeBeamMigrationBackend :: ( BeamMigrateSqlBackend be
-                              , Typeable be
-                              , Fail.MonadFail m -- TODO check whether this is good
-                              )
+  SomeBeamMigrationBackend :: Typeable be
                            => BeamMigrationBackend be m
                            -> SomeBeamMigrationBackend
 

--- a/beam-migrate/Database/Beam/Migrate/Backend.hs
+++ b/beam-migrate/Database/Beam/Migrate/Backend.hs
@@ -74,7 +74,7 @@ type DdlError = String
 data BeamMigrationBackend be m where
   BeamMigrationBackend ::
     ( MonadBeam be m
-    , Fail.MonadFail m -- TODO check whether this is good
+    , Fail.MonadFail m
     , HasQBuilder be
     , BeamMigrateSqlBackend be
     , HasDataTypeCreatedCheck (BeamMigrateSqlBackendDataTypeSyntax be)

--- a/beam-migrate/Database/Beam/Migrate/Backend.hs
+++ b/beam-migrate/Database/Beam/Migrate/Backend.hs
@@ -54,6 +54,7 @@ import           Database.Beam.Migrate.Types
 import           Database.Beam.Haskell.Syntax
 
 import           Control.Applicative
+import qualified Control.Monad.Fail as Fail
 
 #if ! MIN_VERSION_base(4,11,0)
 import           Data.Semigroup
@@ -96,7 +97,9 @@ data BeamMigrationBackend be m where
 -- polymorphism
 data SomeBeamMigrationBackend where
   SomeBeamMigrationBackend :: ( BeamMigrateSqlBackend be
-                              , Typeable be )
+                              , Typeable be
+                              , Fail.MonadFail m -- TODO check whether this is good
+                              )
                            => BeamMigrationBackend be m
                            -> SomeBeamMigrationBackend
 


### PR DESCRIPTION
Otherwise the migration, which can fail, cannot be run.