### PR TITLE
Make `isJust_` == `not . isNothing_`

### DIFF
--- a/beam-core/Database/Beam/Query/Combinators.hs
+++ b/beam-core/Database/Beam/Query/Combinators.hs
@@ -841,7 +841,7 @@ instance BeamSqlBackend be => SqlDeconstructMaybe be (QGenExpr ctxt be s (Maybe 
 
 instance ( BeamSqlBackend be, Beamable t)
     => SqlDeconstructMaybe be (t (Nullable (QGenExpr ctxt be s))) (t (QGenExpr ctxt be s)) s where
-    isJust_ t = allE (allBeamValues (\(Columnar' e) -> isJust_ e) t)
+    isJust_ = not_ . isNothing_
     isNothing_ t = allE (allBeamValues (\(Columnar' e) -> isNothing_ e) t)
     maybe_ (QExpr onNothing) onJust tbl =
       let QExpr onJust' = onJust (changeBeamRep (\(Columnar' (QExpr e)) -> Columnar' (QExpr e)) tbl)


### PR DESCRIPTION
Right now `isJust_` returns `False` for a `RowT (Nullable (QGenExpr ctxt be s))` where
```
data RowT f =
  RowT
    { _uuid :: !(C f Text)
    , _foo :: !(C f (Maybe Int))
    }
  deriving anyclass (Beamable)
  deriving (Generic)
```
if the `_foo :: !(C f (Maybe Int))` field is `null`, even if `_uuid :: !(C f Text)` is `non-null`.

Perhaps this is intended behaviour, but I find it confusing that a `isJust_ x = False` for the same `x` for which `isNothing_ x = False`.

Please let me know if the PR is missing something, if something is unclear or if I'm plain wrong. :)