### PR TITLE
Add liftIOWithHandle :: (Connection -> IO a) -> Pg a

### DIFF
--- a/beam-postgres/Database/Beam/Postgres.hs
+++ b/beam-postgres/Database/Beam/Postgres.hs
@@ -19,7 +19,7 @@
 
 module Database.Beam.Postgres
   (  -- * Beam Postgres backend
-    Postgres(..), Pg
+    Postgres(..), Pg, liftIOWithHandle
 
     -- ** Postgres syntax
   , PgCommandSyntax, PgSyntax

--- a/beam-postgres/Database/Beam/Postgres/Connection.hs
+++ b/beam-postgres/Database/Beam/Postgres/Connection.hs
@@ -15,6 +15,8 @@
 module Database.Beam.Postgres.Connection
   ( Pg(..), PgF(..)
 
+  , liftIOWithHandle
+
   , runBeamPostgres, runBeamPostgresDebug
 
   , pgRenderSyntax, runPgRowReader, getFields
@@ -293,6 +295,9 @@ instance Fail.MonadFail Pg where
 
 instance MonadIO Pg where
     liftIO x = liftF (PgLiftIO x id)
+
+liftIOWithHandle :: (Pg.Connection -> IO a) -> Pg a
+liftIOWithHandle f = liftF (PgLiftWithHandle f id)
 
 runBeamPostgresDebug :: (String -> IO ()) -> Pg.Connection -> Pg a -> IO a
 runBeamPostgresDebug dbg conn action =

--- a/beam-postgres/Database/Beam/Postgres/Debug.hs
+++ b/beam-postgres/Database/Beam/Postgres/Debug.hs
@@ -4,7 +4,8 @@ module Database.Beam.Postgres.Debug where
 import           Database.Beam.Query
 import           Database.Beam.Postgres.Types (Postgres(..))
 import           Database.Beam.Postgres.Connection
-  ( Pg, PgF(..)
+  ( Pg
+  , liftIOWithHandle
   , pgRenderSyntax )
 import           Database.Beam.Postgres.Full
   ( PgInsertReturning(..)
@@ -16,8 +17,6 @@ import Database.Beam.Postgres.Syntax
   , PgInsertSyntax(..)
   , PgUpdateSyntax(..)
   , PgDeleteSyntax(..) )
-
-import           Control.Monad.Free ( liftF )
 
 import qualified Data.ByteString.Char8 as BC
 import           Data.Maybe (maybe)
@@ -69,5 +68,5 @@ pgTraceStmtIO' conn stmt =
 
 pgTraceStmt :: PgDebugStmt statement => statement -> Pg ()
 pgTraceStmt stmt =
-  liftF (PgLiftWithHandle (flip pgTraceStmtIO stmt) id)
+  liftIOWithHandle (flip pgTraceStmtIO stmt)
 

--- a/beam-postgres/Database/Beam/Postgres/Migrate.hs
+++ b/beam-postgres/Database/Beam/Postgres/Migrate.hs
@@ -54,7 +54,6 @@ import           Control.Applicative ((<|>))
 import           Control.Arrow
 import           Control.Exception (bracket)
 import           Control.Monad
-import           Control.Monad.Free.Church (liftF)
 
 import           Data.Aeson hiding (json)
 import           Data.Bits
@@ -89,7 +88,7 @@ migrationBackend = Tool.BeamMigrationBackend
                                  , "  postgresql://[user[:password]@][netloc][:port][/dbname][?param1=value1&...]"
                                  , ""
                                  , "See <https://www.postgresql.org/docs/9.5/static/libpq-connect.html#LIBPQ-CONNSTRING> for more information" ])
-                        (liftF (PgLiftWithHandle getDbConstraints id))
+                        (liftIOWithHandle getDbConstraints)
                         (Db.sql92Deserializers <> Db.sql99DataTypeDeserializers <>
                          Db.sql2008BigIntDataTypeDeserializers <>
                          postgresDataTypeDeserializers <>


### PR DESCRIPTION
That allows to override `getDbConstraints` in migration backend.