### PR TITLE
Add PolyKinds to modules deriving for Data.Tagged

### DIFF
--- a/beam-core/Database/Beam/Backend/SQL.hs
+++ b/beam-core/Database/Beam/Backend/SQL.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE UndecidableInstances #-}
 module Database.Beam.Backend.SQL
   ( module Database.Beam.Backend.SQL.Row

--- a/beam-core/Database/Beam/Backend/SQL/Row.hs
+++ b/beam-core/Database/Beam/Backend/SQL/Row.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE PolyKinds #-}
 
 module Database.Beam.Backend.SQL.Row
   ( FromBackendRowF(..), FromBackendRowM(..)

--- a/beam-postgres/Database/Beam/Postgres/Types.hs
+++ b/beam-postgres/Database/Beam/Postgres/Types.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PolyKinds #-}
 
 module Database.Beam.Postgres.Types
   ( Postgres(..)


### PR DESCRIPTION
This allows Tagged's phantom type to be of kind `Symbol`.

Context: https://haskell.zettel.page/047d9f68.html