### PR TITLE
Added Postgres specific || operator for concatenating two jsonb values

### DIFF
--- a/beam-postgres/Database/Beam/Postgres/PgSpecific.hs
+++ b/beam-postgres/Database/Beam/Postgres/PgSpecific.hs
@@ -32,7 +32,7 @@ module Database.Beam.Postgres.PgSpecific
 
   , (@>), (<@), (->#), (->$)
   , (->>#), (->>$), (#>), (#>>)
-  , (?), (?|), (?&)
+  , (?), (?|), (?&), (||.)
 
   , withoutKey, withoutIdx
   , withoutKeys
@@ -114,7 +114,7 @@ module Database.Beam.Postgres.PgSpecific
   )
 where
 
-import           Database.Beam hiding (char, double)
+import           Database.Beam hiding ((||.), char, double)
 import           Database.Beam.Backend.SQL
 import           Database.Beam.Migrate ( HasDefaultSqlDataType(..) )
 import           Database.Beam.Postgres.Syntax
@@ -959,6 +959,13 @@ QExpr a ?| QExpr b =
   QExpr (pgBinOp "?|" <$> a <*> b)
 QExpr a ?& QExpr b =
   QExpr (pgBinOp "?&" <$> a <*> b)
+
+-- | Postgres @||@ operator. Concatenates two jsonb values into a new jsonb value.
+(||.) :: QGenExpr ctxt Postgres s (PgJSONB a)
+      -> QGenExpr ctxt Postgres s (PgJSONB a)
+      -> QGenExpr ctxt Postgres s (PgJSONB a)
+QExpr a ||. QExpr b =
+  QExpr (pgBinOp "||" <$> a <*> b)
 
 -- | Postgres @-@ operator on json objects. Returns the supplied json object
 -- with the supplied key deleted. See 'withoutIdx' for the corresponding


### PR DESCRIPTION
I am not sure if the operator naming is correct and if it is ok to introduce these PostgreSQL specific operators like this (not so much experienced in Haskell yet). But anyway, I try my luck and hope at least to get feedback on how to do it correctly :D.
Here is the official description of the `||` jsonb-concatenator operator as well as some more https://www.postgresql.org/docs/11/functions-json.html (maybe I can add some more ;) ).
Thank you.