### PR TITLE
postgres: Report json decoding errors

### DIFF
--- a/beam-postgres/Database/Beam/Postgres/PgSpecific.hs
+++ b/beam-postgres/Database/Beam/Postgres/PgSpecific.hs
@@ -709,9 +709,10 @@ instance (Typeable x, FromJSON x) => Pg.FromField (PgJSON x) where
   fromField field d =
     if Pg.typeOid field /= Pg.typoid Pg.json
     then Pg.returnError Pg.Incompatible field ""
-    else case decodeStrict =<< d of
-           Just d' -> pure (PgJSON d')
+    else case eitherDecodeStrict <$> d of
            Nothing -> Pg.returnError Pg.UnexpectedNull field ""
+           Just (Left e) -> Pg.returnError Pg.ConversionFailed field e
+           Just (Right d') -> pure (PgJSON d')
 
 instance (Typeable a, FromJSON a) => FromBackendRow Postgres (PgJSON a)
 instance ToJSON a => HasSqlValueSyntax PgValueSyntax (PgJSON a) where
@@ -734,9 +735,10 @@ instance (Typeable x, FromJSON x) => Pg.FromField (PgJSONB x) where
   fromField field d =
     if Pg.typeOid field /= Pg.typoid Pg.jsonb
     then Pg.returnError Pg.Incompatible field ""
-    else case decodeStrict =<< d of
-           Just d' -> pure (PgJSONB d')
+    else case eitherDecodeStrict <$> d of
            Nothing -> Pg.returnError Pg.UnexpectedNull field ""
+           Just (Left e) -> Pg.returnError Pg.ConversionFailed field e
+           Just (Right d') -> pure (PgJSONB d')
 
 instance (Typeable a, FromJSON a) => FromBackendRow Postgres (PgJSONB a)
 instance ToJSON a => HasSqlValueSyntax PgValueSyntax (PgJSONB a) where


### PR DESCRIPTION
This one really confused me for a while. I was wondering where in the database was null being used (all my fields had `NOT NULL` constraint). Turns out the `FromField` instance for PgJSONB (and PgJSON) ignores aeson errors and reports them (incorrectly) as "UnexpectedNull". 

This PR fixes that by:

a) throwing UnexpectedNull only when the argument value is Nothing
b) using aeson's `eitherDecodeStrict` to report the error back to the library user 
