### PR TITLE
Bump dependent-{map,sum} upper bounds in beam-migrate cabal file

### DIFF
--- a/beam-migrate/beam-migrate.cabal
+++ b/beam-migrate/beam-migrate.cabal
@@ -79,8 +79,8 @@ library
                        containers           >=0.5     && <0.7,
                        haskell-src-exts     >=1.18    && <1.22,
                        pretty               >=1.1     && <1.2,
-                       dependent-map        >=0.2     && <0.4,
-                       dependent-sum        >=0.4     && <0.7,
+                       dependent-map        >=0.2     && <0.5,
+                       dependent-sum        >=0.4     && <0.8,
                        pqueue               >=1.3     && <1.5,
                        uuid-types           >=1.0     && <1.1
   default-language:    Haskell2010


### PR DESCRIPTION
I tested build and execution with these updates and everything works fine.
Needed it to build on `nixos-unstable` snapshot from around May 18 without `haskell.lib.addPatch`.