### PR TITLE
Remove some unused imports and definitions

### DIFF
--- a/beam-core/test/Database/Beam/Test/SQL.hs
+++ b/beam-core/test/Database/Beam/Test/SQL.hs
@@ -10,7 +10,6 @@ module Database.Beam.Test.SQL
 import Database.Beam.Test.Schema hiding (tests)
 
 import Database.Beam
-import Database.Beam.Query.Internal
 import Database.Beam.Backend.SQL (MockSqlBackend)
 import Database.Beam.Backend.SQL.AST
 

--- a/beam-core/test/Database/Beam/Test/Schema.hs
+++ b/beam-core/test/Database/Beam/Test/Schema.hs
@@ -16,11 +16,8 @@ module Database.Beam.Test.Schema
 import           Database.Beam
 import           Database.Beam.Schema.Tables
 import           Database.Beam.Backend
-import           Database.Beam.Backend.SQL.AST
 
 import           Data.List.NonEmpty ( NonEmpty((:|)) )
-import           Data.Monoid
-import           Data.Proxy
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Time.Clock (UTCTime)
@@ -117,9 +114,6 @@ instance Beamable (PrimaryKey RoleT)
 deriving instance Show (TableSettings (PrimaryKey RoleT))
 deriving instance Eq (TableSettings (PrimaryKey RoleT))
 
-roleTableSchema :: TableSettings RoleT
-roleTableSchema = defTblFieldSettings
-
 -- * Ensure that fields of a nullable primary key are given the proper Maybe type
 
 data DepartmentT f
@@ -134,9 +128,6 @@ instance Table DepartmentT where
 instance Beamable (PrimaryKey DepartmentT)
 deriving instance Show (TableSettings DepartmentT)
 deriving instance Eq (TableSettings DepartmentT)
-
-departmentTableSchema :: TableSettings DepartmentT
-departmentTableSchema = defTblFieldSettings
 
 -- nullableForeignKeysGivenMaybeType :: TestTree
 -- nullableForeignKeysGivenMaybeType =
@@ -227,7 +218,6 @@ parametricAndFixedNestedBeamsAreEquivalent =
 -- `ADepartmentVehiculeT` and `BDepartmentVehiculeT` are equivalent, but one was using params while
 -- the other had its sub-beams fixed.
 
-type ADepartmentVehicule   = ADepartmentVehiculeT Identity
 type ADepartmentVehiculeT  = DepartamentRelatedT VehiculeInformationT VehiculeT
 data DepartamentRelatedT metaInfo prop f = DepartamentProperty
       { _aDepartament  :: PrimaryKey DepartmentT f
@@ -235,7 +225,6 @@ data DepartamentRelatedT metaInfo prop f = DepartamentProperty
       , _aMetaInfo     :: metaInfo (Nullable f)
       } deriving Generic
 
-type BDepartmentVehicule    = BDepartmentVehiculeT Identity
 data BDepartmentVehiculeT f = BDepartmentVehicule
       { _bDepartament  :: PrimaryKey DepartmentT f
       , _bRelatesTo    :: VehiculeT f
@@ -323,7 +312,7 @@ employeeDbSettingsRuleMods = defaultDbSettings `withDbModification`
                                                 let defName = defaultFieldName field
                                                 in case T.stripPrefix "funny" defName of
                                                   Nothing -> defName
-                                                  Just fieldNm -> "pfx_" <> defName)
+                                                  Just _ -> "pfx_" <> defName)
 
 -- employeeDbSettingsModified :: DatabaseSettings EmployeeDb
 -- employeeDbSettingsModified =

--- a/beam-migrate-cli/Database/Beam/Migrate/Tool/Migrate.hs
+++ b/beam-migrate-cli/Database/Beam/Migrate/Tool/Migrate.hs
@@ -8,7 +8,6 @@ import           Database.Beam.Migrate.Tool.Registry
 import           Database.Beam.Migrate.Tool.Status
 
 import           Control.Applicative
-import           Control.Exception
 import           Control.Monad
 import qualified Control.Monad.Fail as Fail
 
@@ -16,13 +15,11 @@ import qualified Data.ByteString.Char8 as BS
 import           Data.Char as Char
 import           Data.Graph.Inductive.Graph
 import qualified Data.Graph.Inductive.Query as Gr
-import qualified Data.HashSet as HS
 import           Data.List (find)
 import           Data.List.Split (splitWhen)
 import           Data.String
 import           Data.Text (Text)
 import qualified Data.Text as T
-import           Data.Typeable
 import           Data.UUID (UUID)
 
 import           System.IO

--- a/beam-migrate-cli/Database/Beam/Migrate/Tool/Status.hs
+++ b/beam-migrate-cli/Database/Beam/Migrate/Tool/Status.hs
@@ -7,7 +7,6 @@ import           Database.Beam.Migrate.Tool.CmdLine
 import           Database.Beam.Migrate.Tool.Diff
 import           Database.Beam.Migrate.Tool.Registry
 
-import           Data.Monoid
 import           Data.Text (unpack)
 import qualified Data.Text as T
 import           Data.Time (LocalTime)

--- a/beam-postgres/test/Database/Beam/Postgres/Test.hs
+++ b/beam-postgres/test/Database/Beam/Postgres/Test.hs
@@ -7,7 +7,7 @@ import           Prelude hiding (fail)
 
 import qualified Database.PostgreSQL.Simple as Pg
 
-import           Control.Exception (SomeException(..), bracket, catch)
+import           Control.Exception (bracket)
 import           Control.Concurrent (threadDelay)
 
 import           Control.Monad (void)
@@ -16,7 +16,6 @@ import           Control.Monad.Fail (MonadFail(..))
 #endif
 
 import           Data.ByteString (ByteString)
-import           Data.Semigroup
 import           Data.String
 
 import qualified Hedgehog
@@ -38,14 +37,13 @@ withTestPostgres dbName getConnStr action = do
       withTemplate1 = bracket (Pg.connectPostgreSQL connStrTemplate1) Pg.close
 
       createDatabase = withTemplate1 $ \c -> do
-                         Pg.execute_ c (fromString ("CREATE DATABASE " <> dbName))
+                         void $ Pg.execute_ c (fromString ("CREATE DATABASE " <> dbName))
 
                          Pg.connectPostgreSQL connStrDb
       dropDatabase c = do
         Pg.close c
-        withTemplate1 $ \c' -> do
-            Pg.execute_ c' (fromString ("DROP DATABASE " <> dbName))
-            pure ()
+        withTemplate1 $ \c' -> void $
+          Pg.execute_ c' (fromString ("DROP DATABASE " <> dbName))
 
   bracket createDatabase dropDatabase action
 
@@ -57,19 +55,22 @@ startTempPostgres = do
   callProcess "pg_ctl" [ "init", "-D", pgDataDir ]
 
   -- Use 'D' because otherwise, the path is too long on OS X
-  pgHdl <- spawnProcess "postgres"
-                        [ "-D", pgDataDir
-                        , "-k", pgDataDir, "-h", "" ]
+  void $ spawnProcess "postgres"
+    [ "-D", pgDataDir
+    , "-k", pgDataDir, "-h", ""
+    ]
 
   putStrLn ("Using " ++ pgDataDir ++ " as postgres host")
 
-  let waitForPort 10 = fail "Could not connect to postgres"
+  let waitForPort :: Word -> IO ()
+      waitForPort 10 = fail "Could not connect to postgres"
       waitForPort n = do
-        (code, stdout, stderr) <- readProcessWithExitCode "pg_ctl" [ "status", "-D", pgDataDir ] ""
+        (code, _, _) <- readProcessWithExitCode "pg_ctl" [ "status", "-D", pgDataDir ] ""
         case code of
           ExitSuccess -> waitForSocket 0
           ExitFailure _ -> threadDelay 1000000 >> waitForPort (n + 1)
 
+      waitForSocket :: Word -> IO ()
       waitForSocket 10 = fail "Could not connect to postgres (waitForSocket)"
       waitForSocket n = do
         skExists <- doesFileExist (pgDataDir </> ".s.PGSQL.5432")

--- a/beam-postgres/test/Database/Beam/Postgres/Test/DataTypes.hs
+++ b/beam-postgres/test/Database/Beam/Postgres/Test/DataTypes.hs
@@ -4,7 +4,6 @@ module Database.Beam.Postgres.Test.DataTypes where
 
 import Database.Beam
 import Database.Beam.Postgres
-import Database.Beam.Postgres.Migrate
 import Database.Beam.Postgres.Test
 import Database.Beam.Migrate
 import Database.Beam.Backend.SQL.BeamExtensions
@@ -68,7 +67,7 @@ jsonNulTest pgConn =
           fmap (fmap (\(PgJSON v) -> v)) $
             runSelectReturningList $ select $
             fmap (\(JsonT _ v) -> v) $
-            orderBy_ (\(JsonT pk _) -> asc_ pk) $
+            orderBy_ (\(JsonT k _) -> asc_ k) $
             all_ (jsonTable db)
 
       readback @?= [ "hello\0world"
@@ -129,7 +128,7 @@ errorOnSchemaMismatch pgConn =
                                                         (WrongTbl (field "key" int notNull)
                                                                   (field "value" int notNull)))
 
-      didFail <- handle (\(e :: SomeException) -> pure True) $
+      didFail <- handle (\(_ :: SomeException) -> pure True) $
         runBeamPostgres conn $ do
           _ <- runInsertReturningList $ insert (_wrongTbl wrongDb) $ insertValues [ WrongTbl 4 23, WrongTbl 5 24, WrongTbl 6 24 ]
           pure False

--- a/beam-postgres/test/Database/Beam/Postgres/Test/Marshal.hs
+++ b/beam-postgres/test/Database/Beam/Postgres/Test/Marshal.hs
@@ -9,15 +9,12 @@ import           Database.Beam.Migrate.Simple (autoMigrate)
 import           Database.Beam.Postgres
 import           Database.Beam.Postgres.Migrate (migrationBackend)
 import           Database.Beam.Postgres.Test
-import qualified Database.PostgreSQL.Simple as Pg
 
 import           Data.ByteString (ByteString)
 import           Data.Functor.Classes
 import           Data.Int
 import           Data.Proxy (Proxy(..))
-import           Data.Semigroup
 import qualified Data.Text as T
-import qualified Data.Text.Lazy as TL
 import           Data.Typeable
 import           Data.UUID (UUID, fromWords)
 import           Data.Word

--- a/beam-postgres/test/Database/Beam/Postgres/Test/Select.hs
+++ b/beam-postgres/test/Database/Beam/Postgres/Test/Select.hs
@@ -1,36 +1,9 @@
 module Database.Beam.Postgres.Test.Select where
 
-import           Database.Beam
-import           Database.Beam.Backend.SQL
-import           Database.Beam.Backend.SQL.BeamExtensions
-import           Database.Beam.Migrate
-import           Database.Beam.Migrate.Simple (autoMigrate)
-import           Database.Beam.Postgres
-import           Database.Beam.Postgres.Migrate (migrationBackend)
-import           Database.Beam.Postgres.Test
-import qualified Database.PostgreSQL.Simple as Pg
-
 import           Data.ByteString (ByteString)
-import           Data.Functor.Classes
-import           Data.Int
-import           Data.Proxy (Proxy(..))
-import           Data.Semigroup
-import qualified Data.Text as T
-import qualified Data.Text.Lazy as TL
-import           Data.Typeable
-import           Data.UUID (UUID, fromWords)
-import           Data.Word
-
-import qualified Hedgehog
-import           Hedgehog ((===))
-import qualified Hedgehog.Gen as Gen
-import qualified Hedgehog.Range as Range
 
 import           Test.Tasty
-import           Test.Tasty.HUnit
-
-import           Unsafe.Coerce
 
 tests :: IO ByteString -> TestTree
-tests postgresConn =
+tests _ =
     testGroup "Postgres Select Tests" []


### PR DESCRIPTION
I left unused variables in `beam-migrate-cli` alone since a lot of that is unimplemented.