### PR TITLE
Upgrade checkout action to v2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v10
     - uses: cachix/cachix-action@v6
       with:


### PR DESCRIPTION
This does a shallow checkout of only the needed revision.