### PR TITLE
Add 'week' to date extraction

### DIFF
--- a/beam-core/Database/Beam/Backend/SQL/AST.hs
+++ b/beam-core/Database/Beam/Backend/SQL/AST.hs
@@ -156,6 +156,7 @@ data ExtractField
 
   | ExtractFieldDateTimeYear
   | ExtractFieldDateTimeMonth
+  | ExtractFieldDateTimeWeek
   | ExtractFieldDateTimeDay
   | ExtractFieldDateTimeHour
   | ExtractFieldDateTimeMinute
@@ -290,6 +291,7 @@ instance IsSql92ExtractFieldSyntax ExtractField where
   minutesField = ExtractFieldDateTimeMinute
   hourField = ExtractFieldDateTimeHour
   dayField = ExtractFieldDateTimeDay
+  weekField = ExtractFieldDateTimeWeek
   monthField = ExtractFieldDateTimeMonth
   yearField = ExtractFieldDateTimeYear
 

--- a/beam-core/Database/Beam/Backend/SQL/Builder.hs
+++ b/beam-core/Database/Beam/Backend/SQL/Builder.hs
@@ -191,6 +191,7 @@ instance IsSql92ExtractFieldSyntax SqlSyntaxBuilder where
   minutesField = SqlSyntaxBuilder (byteString "MINUTE")
   hourField    = SqlSyntaxBuilder (byteString "HOUR")
   dayField     = SqlSyntaxBuilder (byteString "DAY")
+  weekField    = SqlSyntaxBuilder (byteString "WEEK")
   monthField   = SqlSyntaxBuilder (byteString "MONTH")
   yearField    = SqlSyntaxBuilder (byteString "YEAR")
 

--- a/beam-core/Database/Beam/Backend/SQL/SQL92.hs
+++ b/beam-core/Database/Beam/Backend/SQL/SQL92.hs
@@ -206,6 +206,7 @@ class IsSql92ExtractFieldSyntax extractField where
   minutesField :: extractField
   hourField :: extractField
   dayField :: extractField
+  weekField :: extractField
   monthField :: extractField
   yearField :: extractField
 

--- a/beam-core/Database/Beam/Query/Extract.hs
+++ b/beam-core/Database/Beam/Query/Extract.hs
@@ -7,7 +7,7 @@ module Database.Beam.Query.Extract
 
       -- ** SQL92 fields
       hour_, minutes_, seconds_,
-      year_, month_, day_,
+      year_, month_, week_, day_,
 
       HasSqlTime, HasSqlDate
     ) where
@@ -53,9 +53,10 @@ instance HasSqlDate LocalTime
 instance HasSqlDate UTCTime
 instance HasSqlDate Day
 
-year_, month_, day_
+year_, month_, week_, day_
     :: ( BeamSqlBackend be, HasSqlDate tgt )
     => ExtractField be tgt Double
 year_  = ExtractField yearField
 month_ = ExtractField monthField
 day_   = ExtractField dayField
+week_  = ExtractField weekField

--- a/beam-migrate/Database/Beam/Haskell/Syntax.hs
+++ b/beam-migrate/Database/Beam/Haskell/Syntax.hs
@@ -627,6 +627,7 @@ instance IsSql92ExtractFieldSyntax HsExpr where
   hourField    = hsVar "hourField"
   yearField    = hsVar "yearField"
   monthField   = hsVar "monthField"
+  weekField     = hsVar "weekField"
   dayField     = hsVar "dayField"
 
 instance IsSql92ExpressionSyntax HsExpr where

--- a/beam-postgres/Database/Beam/Postgres/Syntax.hs
+++ b/beam-postgres/Database/Beam/Postgres/Syntax.hs
@@ -696,6 +696,7 @@ instance IsSql92ExtractFieldSyntax PgExtractFieldSyntax where
   minutesField = PgExtractFieldSyntax (emit "MINUTE")
   hourField    = PgExtractFieldSyntax (emit "HOUR")
   dayField     = PgExtractFieldSyntax (emit "DAY")
+  weekField    = PgExtractFieldSyntax (emit "WEEK")
   monthField   = PgExtractFieldSyntax (emit "MONTH")
   yearField    = PgExtractFieldSyntax (emit "YEAR")
 

--- a/beam-sqlite/Database/Beam/Sqlite/Syntax.hs
+++ b/beam-sqlite/Database/Beam/Sqlite/Syntax.hs
@@ -931,6 +931,7 @@ sqliteExtract field from =
       ExtractFieldDateTimeYear   -> extractStrftime "%Y"
       ExtractFieldDateTimeMonth  -> extractStrftime "%m"
       ExtractFieldDateTimeDay    -> extractStrftime "%d"
+      ExtractFieldDateTimeWeek   -> extractStrftime "%W"
       ExtractFieldDateTimeHour   -> extractStrftime "%H"
       ExtractFieldDateTimeMinute -> extractStrftime "%M"
       ExtractFieldDateTimeSecond -> extractStrftime "%S"


### PR DESCRIPTION
This change adds the `week_` field to the list of fields that can be extract from `HasSqlDate` compatible fields.

This will be a breaking change for anyone that manipulates or consumes the AST as there is a new field added to the `IsSql92ExtractFieldSyntax ` typeclass and a new constructor to `ExtractField`.