### PR TITLE
Update microlens bounds to include 0.5

### DIFF
--- a/beam-core/beam-core.cabal
+++ b/beam-core/beam-core.cabal
@@ -65,7 +65,7 @@ library
                        text         >=1.2.2.0 && <2.2,
                        bytestring   >=0.10    && <0.13,
                        mtl          >=2.2.1   && <2.4,
-                       microlens    >=0.4     && <0.5,
+                       microlens    >=0.4     && <0.6,
                        ghc-prim     >=0.5     && <0.14,
                        free         >=4.12    && <5.3,
                        dlist        >=0.7.1.2 && <1.1,

--- a/beam-migrate/beam-migrate.cabal
+++ b/beam-migrate/beam-migrate.cabal
@@ -66,7 +66,7 @@ library
                        containers           >=0.5     && <0.9,
                        unordered-containers >=0.2     && <0.3,
                        hashable             >=1.2     && <1.6,
-                       microlens            >=0.4     && <0.5,
+                       microlens            >=0.4     && <0.6,
                        parallel             >=3.2     && <3.3,
                        deepseq              >=1.4     && <1.7,
                        haskell-src-exts     >=1.18    && <1.24,

--- a/docs.sh
+++ b/docs.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+dir=$(mktemp -d dist-docs.XXXXXX)
+
+# assumes cabal 2.4 or later
+cabal v2-haddock beam-postgres --builddir="$dir" --haddock-for-hackage --enable-doc


### PR DESCRIPTION
This changeset updates the bounds on `microlens` to include the new 0.5 version.

I tested that compilation with `microlens` 0.5 is supported by running

```
cabal update && cabal build all --constraint='microlens>=0.5'
```