### PR TITLE
import RowParser constructor from Internal

### DIFF
--- a/beam-duckdb/src/Database/Beam/DuckDB.hs
+++ b/beam-duckdb/src/Database/Beam/DuckDB.hs
@@ -89,7 +89,8 @@ import Database.Beam.DuckDB.Syntax.Builder
   )
 import Database.Beam.DuckDB.Syntax.Extensions.DataSource
 import Database.DuckDB.Simple (Connection, FromRow, Query (Query), ResultError (..), RowParser, ToField (toField), ToRow (toRow), bind, execute, nextRow, withStatement)
-import Database.DuckDB.Simple.FromRow (FromRow (..), RowParser (..), field)
+import Database.DuckDB.Simple.FromRow (FromRow (..), field)
+import Database.DuckDB.Simple.Internal (RowParser (..))
 import Database.DuckDB.Simple.Ok (Ok (..))
 
 -- | 'MonadBeam' instance inside which DuckDB queries are run. See the


### PR DESCRIPTION
Resolves https://github.com/Tritlo/duckdb-haskell/issues/6 conditional on https://github.com/Tritlo/duckdb-haskell/pull/11

Since that PR is not merged, this is sent as a PR to be used as a patch for nixpkgs. 

I didn't bump the version in the `.cabal` file since the breaking change to `FromRow` not exporting `RowParser`'s constructor is still a breaking change.