### PR TITLE
Add support for foreign key constraints and foreign key actions

### DIFF
--- a/beam-migrate/ChangeLog.md
+++ b/beam-migrate/ChangeLog.md
@@ -1,3 +1,16 @@
+
+# Unreleased
+
+## Added features
+
+* Added support for foreign key constraints:
+
+  * New `ForeignKeyAction` datatype representing possible actions when updating
+    or deleting a row with referencing foreign keys.
+  * The `IsSql92TableConstraintSyntax` typeclass now has an additional method,
+    `foreignKeyConstraintSyntax`, for constructing foreign key constraint syntax.
+  * Introduce `addTableForeignKey` for declaring new foreign key constraints.
+
 # 0.5.4.0
 
 ## Added features

--- a/beam-migrate/Database/Beam/Haskell/Syntax.hs
+++ b/beam-migrate/Database/Beam/Haskell/Syntax.hs
@@ -25,6 +25,7 @@ import           Data.Char (toLower, toUpper)
 import           Data.Hashable
 import           Data.Int
 import           Data.List (find, nub)
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as M
 import           Data.Maybe
 import qualified Data.Set as S
@@ -584,6 +585,7 @@ instance IsSql92ColumnSchemaSyntax HsColumnSchema where
                             map hsConstraintDefinitionConstraint cs)
 
 instance IsSql92TableConstraintSyntax HsTableConstraint where
+  foreignKeyConstraintSyntax _ _ _ _ _ = HsTableConstraint $ \_ _ -> mempty
   primaryKeyConstraintSyntax fields =
     HsTableConstraint $ \tblNm tblFields ->
     let primaryKeyDataDecl = insDataDecl primaryKeyType [ primaryKeyConDecl ] (Just primaryKeyDeriving)
@@ -591,7 +593,7 @@ instance IsSql92TableConstraintSyntax HsTableConstraint where
         tableTypeNm = tblNm <> "T"
         tableTypeKeyNm = tblNm <> "Key"
 
-        (fieldRecordNames, fieldTys) = unzip (fromMaybe (error "fieldTys") (mapM (hsFieldLookup tblFields) fields))
+        (fieldRecordNames, fieldTys) = unzip (fromMaybe (error "fieldTys") (mapM (hsFieldLookup tblFields) $ NE.toList fields))
 
         primaryKeyType = tyApp (tyConNamed "PrimaryKey") [ tyConNamed (T.unpack tableTypeNm), tyVarNamed "f" ]
         primaryKeyConDecl  = Hs.QualConDecl () Nothing Nothing (Hs.ConDecl () (Hs.Ident () (T.unpack tableTypeKeyNm)) fieldTys)

--- a/beam-migrate/Database/Beam/Migrate/Actions.hs
+++ b/beam-migrate/Database/Beam/Migrate/Actions.hs
@@ -107,6 +107,7 @@ import           Control.Monad
 import           Control.Parallel.Strategies
 
 import           Data.Foldable
+import qualified Data.List.NonEmpty as NE
 
 import qualified Data.HashMap.Strict as HM
 import qualified Data.HashSet as HS
@@ -377,9 +378,41 @@ createTableActionProvider =
            guard (tblNm == postTblNm)
            pure (primaryKeyP, primaryKey)
 
-         let postConditions = [ p tblP, p primaryKeyP ] ++ concat columnsP
+         -- For each foreign key constraint, ensure the referenced table
+         -- already exists in the current state.
+         -- This enforces a topological ordering, so that the solver schedules
+         -- CREATE TABLE for all referenced tables first.
+         --
+         -- Note: this does not support cycles in the foreign key reference graph,
+         -- for which we would need ALTER TABLE ADD CONSTRAINT, which we don't
+         -- currently support.
+         (fkPs, fkConstraints) <- do
+           let fkData =
+                 unzip
+                   [ ( p fkP
+                     , foreignKeyConstraintSyntax localCols (qnameAsText refTbl) refCols onUpd onDel )
+                   | fkP@(TableHasForeignKey tblNm localCols refTbl refCols onUpd onDel)
+                       <- findPostConditions
+                   , tblNm == postTblNm
+                   ]
+               refTbls =
+                 [ refTbl
+                 | TableHasForeignKey tblNm _ refTbl _ _ _ <- findPostConditions
+                 , tblNm == postTblNm
+                 , refTbl /= postTblNm
+                 ]
+           for_ refTbls $ \refTbl -> do
+             TableExistsPredicate nm <- findPreConditions
+             guard (nm == refTbl)
+           pure fkData
+
+
+         let postConditions = [ p tblP, p primaryKeyP ] ++ concat columnsP ++ fkPs
              cmd = createTableCmd (createTableSyntax Nothing (qnameAsTableName postTblNm) colsSyntax tblConstraints)
-             tblConstraints = if null primaryKey then [] else [ primaryKeyConstraintSyntax primaryKey ]
+             tblConstraints = (case NE.nonEmpty primaryKey of
+                                Nothing   -> []
+                                Just pkey -> [primaryKeyConstraintSyntax pkey])
+                           ++ fkConstraints
              colsSyntax = map (\(colNm, type_, cs) -> (colNm, columnSchemaSyntax type_ Nothing cs Nothing)) columns
          pure (PotentialAction mempty (HS.fromList postConditions)
                                (Seq.singleton (MigrationCommand cmd MigrationKeepsData))

--- a/beam-migrate/Database/Beam/Migrate/Checks.hs
+++ b/beam-migrate/Database/Beam/Migrate/Checks.hs
@@ -11,7 +11,8 @@ import Database.Beam.Migrate.SQL.Types
 import Database.Beam.Migrate.Serialization
 import Database.Beam.Migrate.Types.Predicates
 
-import Data.Aeson ((.:), (.=), withObject, object)
+import Data.Aeson ((.:), (.:?), (.=), withObject, object)
+import Data.Maybe (fromMaybe)
 import Data.Aeson.Types (Parser, Value)
 import Data.Hashable (Hashable(..))
 import qualified Data.List.NonEmpty as NE (NonEmpty)
@@ -168,6 +169,67 @@ instance DatabasePredicate TableHasPrimaryKey where
     | Just (TableExistsPredicate tblNm') <- cast p' = tblNm' == tblNm
     | otherwise = False
 
+-- | Asserts that the given table has a foreign key referencing another table.
+-- Create these predicates with
+-- 'Database.Beam.Migrate.Types.CheckedEntities.addTableForeignKey'.
+data TableHasForeignKey
+  = TableHasForeignKey
+  { hasForeignKey_table      :: QualifiedName      -- ^ source table
+  , hasForeignKey_columns    :: NE.NonEmpty Text   -- ^ local columns (in order)
+  , hasForeignKey_refTable   :: QualifiedName      -- ^ referenced table
+  , hasForeignKey_refColumns :: NE.NonEmpty Text   -- ^ referenced columns (in order)
+  , hasForeignKey_onUpdate   :: ForeignKeyAction
+  , hasForeignKey_onDelete   :: ForeignKeyAction
+  } deriving (Show, Eq, Generic)
+instance Hashable TableHasForeignKey
+instance DatabasePredicate TableHasForeignKey where
+  englishDescription (TableHasForeignKey { hasForeignKey_table = tbl
+                                         , hasForeignKey_columns = cols
+                                         , hasForeignKey_refTable = refTbl
+                                         , hasForeignKey_refColumns = refCols
+                                         , hasForeignKey_onUpdate = onUpd
+                                         , hasForeignKey_onDelete = onDel }) =
+    "Table " <> show tbl <> " has foreign key on " <> show cols <>
+    " referencing " <> show refTbl <> " " <> show refCols <>
+    " ON UPDATE " <> show onUpd <>
+    " ON DELETE " <> show onDel
+
+  predicateSpecificity _ = PredicateSpecificityAllBackends
+
+  serializePredicate (TableHasForeignKey { hasForeignKey_table = tbl
+                                         , hasForeignKey_columns = cols
+                                         , hasForeignKey_refTable = refTbl
+                                         , hasForeignKey_refColumns = refCols
+                                         , hasForeignKey_onUpdate = onUpd
+                                         , hasForeignKey_onDelete = onDel }) =
+    object [ "has-foreign-key" .= object
+               [ "table"       .= tbl
+               , "columns"     .= cols
+               , "ref-table"   .= refTbl
+               , "ref-columns" .= refCols
+               , "on-update"   .= serializeForeignKeyAction onUpd
+               , "on-delete"   .= serializeForeignKeyAction onDel
+               ] ]
+
+  predicateCascadesDropOn (TableHasForeignKey { hasForeignKey_table = tblNm }) p'
+    | Just (TableExistsPredicate tblNm') <- cast p' = tblNm' == tblNm
+    | otherwise = False
+
+serializeForeignKeyAction :: ForeignKeyAction -> Text
+serializeForeignKeyAction ForeignKeyActionCascade    = "cascade"
+serializeForeignKeyAction ForeignKeyActionSetNull    = "set-null"
+serializeForeignKeyAction ForeignKeyActionSetDefault = "set-default"
+serializeForeignKeyAction ForeignKeyActionRestrict   = "restrict"
+serializeForeignKeyAction ForeignKeyNoAction         = "no-action"
+
+deserializeForeignKeyAction :: Text -> Maybe ForeignKeyAction
+deserializeForeignKeyAction "cascade"     = Just ForeignKeyActionCascade
+deserializeForeignKeyAction "set-null"    = Just ForeignKeyActionSetNull
+deserializeForeignKeyAction "set-default" = Just ForeignKeyActionSetDefault
+deserializeForeignKeyAction "restrict"    = Just ForeignKeyActionRestrict
+deserializeForeignKeyAction "no-action"   = Just ForeignKeyNoAction
+deserializeForeignKeyAction _             = Nothing
+
 -- * Deserialization
 
 -- | 'BeamDeserializers' for all the predicates defined in this module
@@ -182,6 +244,7 @@ beamCheckDeserializers = mconcat
   , beamDeserializer (const deserializeTableExistsPredicate)
   , beamDeserializer (const deserializeTableHasPrimaryKeyPredicate)
   , beamDeserializer (const deserializeTableHasIndexPredicate)
+  , beamDeserializer (const deserializeTableHasForeignKeyPredicate)
   , beamDeserializer deserializeTableHasColumnPredicate
   , beamDeserializer deserializeTableColumnHasConstraintPredicate
   ]
@@ -213,6 +276,20 @@ beamCheckDeserializers = mconcat
          (TableHasIndex <$> v' .: "table" <*> v' .: "name"
                         <*> v' .: "columns"
                         <*> (deserializeIndexOptions @(BeamSqlBackendSyntax be) =<< v' .: "options")))
+
+    deserializeTableHasForeignKeyPredicate :: Value -> Parser SomeDatabasePredicate
+    deserializeTableHasForeignKeyPredicate =
+      withObject "TableHasForeignKey" $ \v ->
+      v .: "has-foreign-key" >>=
+      (withObject "TableHasForeignKey" $ \v' ->
+       SomeDatabasePredicate <$>
+         (TableHasForeignKey
+           <$> v' .: "table"
+           <*> v' .: "columns"
+           <*> v' .: "ref-table"
+           <*> v' .: "ref-columns"
+           <*> (fromMaybe ForeignKeyNoAction . (>>= deserializeForeignKeyAction) <$> v' .:? "on-update")
+           <*> (fromMaybe ForeignKeyNoAction . (>>= deserializeForeignKeyAction) <$> v' .:? "on-delete")))
 
     deserializeTableHasColumnPredicate :: BeamDeserializers be'
                                        -> Value -> Parser SomeDatabasePredicate

--- a/beam-migrate/Database/Beam/Migrate/SQL/Builder.hs
+++ b/beam-migrate/Database/Beam/Migrate/SQL/Builder.hs
@@ -14,6 +14,7 @@ import           Control.Applicative
 import           Data.ByteString.Builder (Builder, byteString, toLazyByteString)
 import qualified Data.ByteString.Lazy.Char8 as BCL
 
+import qualified Data.List.NonEmpty as NE
 
 -- | Options for @CREATE TABLE@. Given as a separate ADT because the options may
 -- go in different places syntactically.
@@ -124,7 +125,20 @@ instance IsSql92CreateTableSyntax SqlSyntaxBuilder where
 instance IsSql92TableConstraintSyntax SqlSyntaxBuilder where
   primaryKeyConstraintSyntax fs =
     SqlSyntaxBuilder $
-    byteString "PRIMARY KEY(" <> buildSepBy (byteString ", ") (map quoteSql fs) <> byteString ")"
+    byteString "PRIMARY KEY(" <> buildSepBy (byteString ", ") (map quoteSql $ NE.toList fs) <> byteString ")"
+  foreignKeyConstraintSyntax localCols refTbl refCols onUpdate onDelete =
+    SqlSyntaxBuilder $
+    byteString "FOREIGN KEY(" <> buildSepBy (byteString ", ") (map quoteSql $ NE.toList localCols) <> byteString ")" <>
+    byteString " REFERENCES " <> quoteSql refTbl <>
+    byteString "(" <> buildSepBy (byteString ", ") (map quoteSql $ NE.toList refCols) <> byteString ")" <>
+    byteString " ON UPDATE " <> buildSql (sqlForeignKeyAction onUpdate) <>
+    byteString " ON DELETE " <> buildSql (sqlForeignKeyAction onDelete)
+    where
+      sqlForeignKeyAction ForeignKeyActionCascade    = SqlSyntaxBuilder (byteString "CASCADE")
+      sqlForeignKeyAction ForeignKeyActionSetNull    = SqlSyntaxBuilder (byteString "SET NULL")
+      sqlForeignKeyAction ForeignKeyActionSetDefault = SqlSyntaxBuilder (byteString "SET DEFAULT")
+      sqlForeignKeyAction ForeignKeyActionRestrict   = SqlSyntaxBuilder (byteString "RESTRICT")
+      sqlForeignKeyAction ForeignKeyNoAction         = SqlSyntaxBuilder (byteString "NO ACTION")
 
 -- | Some backends use this to represent their constraint attributes. Does not
 -- need to be used in practice.

--- a/beam-migrate/Database/Beam/Migrate/SQL/SQL92.hs
+++ b/beam-migrate/Database/Beam/Migrate/SQL/SQL92.hs
@@ -17,7 +17,8 @@ import Data.Hashable
 import Data.Kind (Type)
 import qualified Data.List.NonEmpty as NE (NonEmpty)
 import Data.Text (Text)
-import Data.Typeable
+import Data.Typeable (Typeable)
+import GHC.Generics (Generic)
 
 -- * Convenience type synonyms
 
@@ -184,8 +185,35 @@ class ( IsSql92ColumnConstraintDefinitionSyntax (Sql92ColumnSchemaColumnConstrai
                      -> Maybe Text {-^ Default collation -}
                      -> columnSchema
 
+-- | Action to perform on referencing foreign keys when a row is modified.
+data ForeignKeyAction
+  = ForeignKeyActionCascade
+    -- ^ @CASCADE@: propagate the action to referencing foreign key columns.
+  | ForeignKeyActionSetNull
+    -- ^ @SET NULL@: set the referencing foreign key colums to @NULL@.
+  | ForeignKeyActionSetDefault
+    -- ^ @SET DEFAULT@: set the referencing foreign key columns to their default
+    -- values.
+  | ForeignKeyActionRestrict
+    -- ^ @RESTRICT@: prohibit modification of a row when foreign key references
+    -- to that row exist.
+  | ForeignKeyNoAction
+    -- ^ @NO ACTION@
+  deriving (Show, Eq, Ord, Generic)
+instance Hashable ForeignKeyAction
+
 class Typeable constraint => IsSql92TableConstraintSyntax constraint where
-  primaryKeyConstraintSyntax :: [ Text ] -> constraint
+  primaryKeyConstraintSyntax :: NE.NonEmpty Text -> constraint
+  -- | Emit a @FOREIGN KEY (cols) REFERENCES tbl (refCols)@ table constraint.
+  --
+  -- Use 'addTableForeignKey' to attach a foreign key to a schema definition.
+  foreignKeyConstraintSyntax
+    :: NE.NonEmpty Text  -- ^ local columns
+    -> Text              -- ^ referenced table name
+    -> NE.NonEmpty Text  -- ^ referenced columns
+    -> ForeignKeyAction  -- ^ ON UPDATE action
+    -> ForeignKeyAction  -- ^ ON DELETE action
+    -> constraint
 
 class Typeable match => IsSql92MatchTypeSyntax match where
   fullMatchSyntax :: match

--- a/beam-migrate/Database/Beam/Migrate/SQL/Tables.hs
+++ b/beam-migrate/Database/Beam/Migrate/SQL/Tables.hs
@@ -55,6 +55,7 @@ import Control.Monad.State
 
 import Data.Coerce (coerce)
 import Data.Kind (Type)
+import qualified Data.List.NonEmpty as NE
 import Data.Text (Text)
 import Data.Typeable
 import qualified Data.Kind as Kind (Constraint)
@@ -143,7 +144,10 @@ createTableWithSchema :: ( Beamable table, Table table
                       -> Migration be (CheckedDatabaseEntity be db (TableEntity table))
 createTableWithSchema maybeSchemaName newTblName tblSettings =
   do let pkFields = allBeamValues (\(Columnar' (TableFieldSchema name _ _)) -> name) (primaryKey tblSettings)
-         tblConstraints = if null pkFields then [] else [ primaryKeyConstraintSyntax pkFields ]
+         tblConstraints =
+          case NE.nonEmpty pkFields of
+            Nothing  -> []
+            Just pks -> [ primaryKeyConstraintSyntax pks ]
          createTableCommand =
            createTableSyntax Nothing (tableName (coerce <$> maybeSchemaName) newTblName)
                              (allBeamValues (\(Columnar' (TableFieldSchema name (FieldSchema schema) _)) -> (name, schema)) tblSettings)

--- a/beam-migrate/Database/Beam/Migrate/SQL/Types.hs
+++ b/beam-migrate/Database/Beam/Migrate/SQL/Types.hs
@@ -19,6 +19,7 @@ module Database.Beam.Migrate.SQL.Types
   , BeamSqlBackendReferentialActionSyntax
   , BeamSqlBackendConstraintAttributesSyntax
   , BeamSqlBackendIndexSyntax
+  , BeamSqlBackendTableConstraintSyntax
   ) where
 
 import Database.Beam.Migrate.Types.Predicates
@@ -94,3 +95,5 @@ type BeamSqlBackendConstraintAttributesSyntax be
   = Sql92DdlCommandConstraintAttributesSyntax (BeamSqlBackendSyntax be)
 type BeamSqlBackendIndexSyntax be
   = Sql92CreateIndexOptionsSyntax (BeamSqlBackendSyntax be)
+type BeamSqlBackendTableConstraintSyntax be
+  = Sql92CreateTableTableConstraintSyntax (Sql92DdlCommandCreateTableSyntax (BeamSqlBackendSyntax be))

--- a/beam-migrate/Database/Beam/Migrate/Types.hs
+++ b/beam-migrate/Database/Beam/Migrate/Types.hs
@@ -30,6 +30,9 @@ module Database.Beam.Migrate.Types
 
   , IsSql92CreateDropIndexSyntax(..)
 
+  , addTableForeignKey
+  , primaryKeyColumns
+
     -- * Predicates
   , DatabasePredicate(..)
   , SomeDatabasePredicate(..)

--- a/beam-migrate/Database/Beam/Migrate/Types/CheckedEntities.hs
+++ b/beam-migrate/Database/Beam/Migrate/Types/CheckedEntities.hs
@@ -298,6 +298,43 @@ addTableIndex idxNm opts getCols =
     in CheckedDatabaseEntity (CheckedDatabaseTable dt (tblChecks ++ [idxCheck]) fieldChecks)
                              extraChecks
 
+-- | Declare a foreign key constraint on a checked table entity.
+--
+-- Example referencing the primary key of a @UserT@ table:
+--
+-- @
+-- addTableForeignKey (db ^. usersTable)
+--   (\\ t -> selectorColumnName _postAuthorId t NE.:| [])
+--   primaryKeyColumns
+--   ForeignKeyNoAction    -- ON UPDATE action
+--   ForeignKeyActionCascade -- ON DELETE action
+-- @
+addTableForeignKey
+  :: forall be db localTbl refTbl.
+     (Table localTbl, Table refTbl)
+  => CheckedDatabaseEntity be db (TableEntity refTbl)         -- ^ referenced table
+  -> (localTbl (TableField localTbl) -> NE.NonEmpty Text)     -- ^ local columns
+  -> (refTbl (TableField refTbl) -> NE.NonEmpty Text)         -- ^ referenced columns
+  -> ForeignKeyAction -- ^ ON UPDATE action
+  -> ForeignKeyAction -- ^ ON DELETE action
+  -> EntityModification (CheckedDatabaseEntity be db) be (TableEntity localTbl)
+addTableForeignKey refTableEntity getLocalFk getRefFk onUpdate onDelete =
+  EntityModification $ Endo $
+  \(CheckedDatabaseEntity (CheckedDatabaseTable dt tblChecks fieldChecks) extraChecks) ->
+    let
+        CheckedDatabaseEntity (CheckedDatabaseTable refDt _ _) _ = refTableEntity
+        refTableName = QualifiedName (dbTableSchema refDt) (dbTableCurrentName refDt)
+
+        localCols = getLocalFk (dbTableSettings dt)
+        refCols   = getRefFk (dbTableSettings refDt)
+
+        fkCheck = TableCheck $ \tblNm _flds ->
+          Just (SomeDatabasePredicate
+                  (TableHasForeignKey tblNm localCols refTableName refCols onUpdate onDelete))
+
+    in CheckedDatabaseEntity (CheckedDatabaseTable dt (tblChecks ++ [fkCheck]) fieldChecks)
+                             extraChecks
+
 -- | Produce a table field modification that does nothing
 --
 --   Most commonly supplied as the second argument to 'modifyCheckedTable' when

--- a/beam-postgres/ChangeLog.md
+++ b/beam-postgres/ChangeLog.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+## Added features
+
+* `getDbConstraintsForSchemas` now discovers foreign key constraints
+  via `pg_constraint`, including `ON DELETE` / `ON UPDATE` actions.
+
 # 0.5.5.0
 
 ## Added features

--- a/beam-postgres/Database/Beam/Postgres/Migrate.hs
+++ b/beam-postgres/Database/Beam/Postgres/Migrate.hs
@@ -31,7 +31,8 @@ module Database.Beam.Postgres.Migrate
   ) where
 
 import           Database.Beam.Backend.SQL
-import           Database.Beam.Migrate.Actions (defaultActionProvider, defaultSchemaActionProvider,
+import           Database.Beam.Migrate.Actions (defaultActionProvider,
+                                               defaultSchemaActionProvider,
                                                createIndexActionProvider, dropIndexActionProvider)
 import qualified Database.Beam.Migrate.Backend as Tool
 import qualified Database.Beam.Migrate.Checks as Db
@@ -450,6 +451,53 @@ getDbConstraintsForSchemas subschemas conn =
          , "  AND NOT EXISTS (SELECT 1 FROM unnest(ix.indkey) AS k(attnum) WHERE k.attnum = 0)"
          , "GROUP BY ns.nspname, c.relname, i.relname, ix.indisunique" ]))
 
+     -- Collect foreign key constraints via pg_constraint.
+     let fkBaseQuery = unlines
+           [ -- NULL out 'public' since it is the implicit default schema in Postgres
+             "SELECT NULLIF(ns.nspname, 'public'),"
+           , "       c.relname,"
+             -- re-aggregate local and referenced column names in key order (see ORDINALITY below)
+           , "       array_agg(a.attname  ORDER BY k.n),"
+           , "       NULLIF(fns.nspname, 'public'),"
+           , "       fc.relname,"
+           , "       array_agg(fa.attname ORDER BY k.n),"
+           , "       con.confupdtype,"
+           , "       con.confdeltype"
+           , "FROM pg_constraint con"
+           , "JOIN pg_class c   ON c.oid   = con.conrelid"
+           , "JOIN pg_namespace ns  ON ns.oid  = c.relnamespace"
+           , "JOIN pg_class fc  ON fc.oid  = con.confrelid"
+           , "JOIN pg_namespace fns ON fns.oid = fc.relnamespace"
+             -- ORDINALITY retains column ordering for both local and referenced sides
+           , "CROSS JOIN unnest(con.conkey, con.confkey)"
+           , "          WITH ORDINALITY AS k(attnum, fattnum, n)"
+           , "JOIN pg_attribute a  ON a.attnum  = k.attnum  AND a.attrelid  = con.conrelid"
+           , "JOIN pg_attribute fa ON fa.attnum = k.fattnum AND fa.attrelid = con.confrelid"
+             -- retain only foreign key constraints
+           , "WHERE con.contype = 'f'" ]
+         mkFkPred (srcSchema, srcTbl, localCols, refSchema, refTbl, refCols, updCode, delCode) =
+           case (NE.nonEmpty (V.toList localCols), NE.nonEmpty (V.toList refCols)) of
+             (Just lcNE, Just rcNE) ->
+               Just $ Db.SomeDatabasePredicate
+                 (Db.TableHasForeignKey (Db.QualifiedName srcSchema srcTbl) lcNE
+                                        (Db.QualifiedName refSchema refTbl)  rcNE
+                                        (parsePgForeignKeyAction updCode)
+                                        (parsePgForeignKeyAction delCode))
+             _ -> Nothing
+     foreignKeyChecks <- mapMaybe mkFkPred <$>
+       case subschemas of
+         Nothing ->
+           Pg.query_ conn (fromString (fkBaseQuery <>
+             "  AND ns.nspname = any(current_schemas(false))\n" <>
+             "GROUP BY ns.nspname, c.relname, con.oid, fns.nspname, fc.relname,\n" <>
+             "         con.confupdtype, con.confdeltype"))
+         Just ss ->
+           Pg.query conn (fromString (fkBaseQuery <>
+             "  AND ns.nspname IN ?\n" <>
+             "GROUP BY ns.nspname, c.relname, con.oid, fns.nspname, fc.relname,\n" <>
+             "         con.confupdtype, con.confdeltype"))
+             (Pg.Only (Pg.In ss))
+
      let enumerations =
            map (\(enumNm, _, options) -> Db.SomeDatabasePredicate (PgHasEnum enumNm (V.toList options))) enumerationData
 
@@ -457,7 +505,25 @@ getDbConstraintsForSchemas subschemas conn =
        map (\(Pg.Only extname) -> Db.SomeDatabasePredicate (PgHasExtension extname)) <$>
        Pg.query_ conn "SELECT extname from pg_extension"
 
-     pure (tblsExist ++ columnChecks ++ primaryKeys ++ secondaryIndices ++ enumerations ++ extensions)
+     pure $
+       concat
+         [ tblsExist
+         , columnChecks
+         , primaryKeys
+         , secondaryIndices
+         , foreignKeyChecks
+         , enumerations
+         , extensions
+         ]
+
+parsePgForeignKeyAction :: Char -> Db.ForeignKeyAction
+parsePgForeignKeyAction 'c' = Db.ForeignKeyActionCascade
+parsePgForeignKeyAction 'n' = Db.ForeignKeyActionSetNull
+parsePgForeignKeyAction 'd' = Db.ForeignKeyActionSetDefault
+parsePgForeignKeyAction 'r' = Db.ForeignKeyActionRestrict
+parsePgForeignKeyAction 'a' = Db.ForeignKeyNoAction
+parsePgForeignKeyAction c   = error $
+  "parsePgForeignKeyAction: unrecognised foreign key action code: " ++ show c
 
 -- * Postgres-specific data types
 

--- a/beam-postgres/Database/Beam/Postgres/Syntax.hs
+++ b/beam-postgres/Database/Beam/Postgres/Syntax.hs
@@ -1179,10 +1179,24 @@ instance IsSql92CreateTableSyntax PgCreateTableSyntax where
                 map fromPgTableConstraint constraints)
        <> emit ")" <> afterOptions
 
+pgForeignKeyAction :: ForeignKeyAction -> PgSyntax
+pgForeignKeyAction ForeignKeyActionCascade    = emit "CASCADE"
+pgForeignKeyAction ForeignKeyActionSetNull    = emit "SET NULL"
+pgForeignKeyAction ForeignKeyActionSetDefault = emit "SET DEFAULT"
+pgForeignKeyAction ForeignKeyActionRestrict   = emit "RESTRICT"
+pgForeignKeyAction ForeignKeyNoAction         = emit "NO ACTION"
+
 instance IsSql92TableConstraintSyntax PgTableConstraintSyntax where
   primaryKeyConstraintSyntax fieldNames =
     PgTableConstraintSyntax $
-    emit "PRIMARY KEY(" <> pgSepBy (emit ", ") (map pgQuotedIdentifier fieldNames) <> emit ")"
+    emit "PRIMARY KEY(" <> pgSepBy (emit ", ") (map pgQuotedIdentifier $ NE.toList fieldNames) <> emit ")"
+  foreignKeyConstraintSyntax localCols refTbl refCols onUpdate onDelete =
+    PgTableConstraintSyntax $
+    emit "FOREIGN KEY(" <> pgSepBy (emit ", ") (map pgQuotedIdentifier $ NE.toList localCols) <> emit ")" <>
+    emit " REFERENCES " <> pgQuotedIdentifier refTbl <>
+    emit "(" <> pgSepBy (emit ", ") (map pgQuotedIdentifier $ NE.toList refCols) <> emit ")" <>
+    emit " ON UPDATE " <> pgForeignKeyAction onUpdate <>
+    emit " ON DELETE " <> pgForeignKeyAction onDelete
 
 instance Hashable PgColumnSchemaSyntax where
   hashWithSalt salt = hashWithSalt salt . fromPgColumnSchema

--- a/beam-postgres/test/Database/Beam/Postgres/Test/Migrate.hs
+++ b/beam-postgres/test/Database/Beam/Postgres/Test/Migrate.hs
@@ -31,6 +31,9 @@ tests postgresConn =
       , dropSchemaWorks postgresConn
       , indexVerification postgresConn
       , uniqueIndexVerification postgresConn
+      , foreignKeyVerification postgresConn
+      , foreignKeyOnDeleteCascadeVerification postgresConn
+      , foreignKeyActionsWork postgresConn
       ]
 
 data CharT f
@@ -189,6 +192,134 @@ uniqueIndexVerification pgConn =
                   (dbModification @_ @Postgres)
                     { _idx_tbl = addTableIndex "idx_tbl_value_uniq" idxOpts
                                    (\t -> selectorColumnName _idx_value t NE.:| []) }
+        runBeamPostgres conn (verifySchema migrationBackend db) >>= \case
+          VerificationSucceeded -> return ()
+          VerificationFailed failures -> fail ("Verification failed: " ++ show failures)
+
+-- Foreign key test tables
+
+data FkParentT f = FkParentT
+  { _fk_parent_id :: C f Int32
+  } deriving (Generic, Beamable)
+
+instance Table FkParentT where
+  newtype PrimaryKey FkParentT f = FkParentPk (C f Int32)
+    deriving (Generic, Beamable)
+  primaryKey = FkParentPk . _fk_parent_id
+
+data FkChildT f = FkChildT
+  { _fk_child_id        :: C f Int32
+  , _fk_child_parent_id :: PrimaryKey FkParentT f
+  } deriving (Generic, Beamable)
+
+instance Table FkChildT where
+  newtype PrimaryKey FkChildT f = FkChildPk (C f Int32)
+    deriving (Generic, Beamable)
+  primaryKey = FkChildPk . _fk_child_id
+
+data FkDb entity = FkDb
+  { _fk_parent :: entity (TableEntity FkParentT)
+  , _fk_child  :: entity (TableEntity FkChildT)
+  } deriving (Generic, Database Postgres)
+
+-- | Verifies that 'verifySchema' correctly detects a plain foreign key
+foreignKeyVerification :: IO ByteString -> TestTree
+foreignKeyVerification pgConn =
+    testCase "verifySchema correctly detects a plain foreign key" $
+      withTestPostgres "db_fk" pgConn $ \conn -> do
+        Pg.execute_ conn "CREATE TABLE fk_parent (fk_parent_id integer NOT NULL PRIMARY KEY)"
+        Pg.execute_ conn "CREATE TABLE fk_child  (fk_child_id integer NOT NULL PRIMARY KEY, \
+                         \fk_child_parent_id integer NOT NULL, \
+                         \FOREIGN KEY (fk_child_parent_id) REFERENCES fk_parent (fk_parent_id))"
+        let db :: CheckedDatabaseSettings Postgres FkDb
+            db = defaultMigratableDbSettings `withDbModification`
+                  (dbModification @_ @Postgres)
+                    { _fk_child =
+                        addTableForeignKey (_fk_parent db)
+                          (foreignKeyColumns _fk_child_parent_id)
+                          primaryKeyColumns
+                          ForeignKeyNoAction
+                          ForeignKeyNoAction
+                        <> modifyCheckedTable id
+                             (FkChildT { _fk_child_id        = "fk_child_id"
+                                       , _fk_child_parent_id = FkParentPk "fk_child_parent_id" }) }
+        runBeamPostgres conn (verifySchema migrationBackend db) >>= \case
+          VerificationSucceeded -> return ()
+          VerificationFailed failures -> fail ("Verification failed: " ++ show failures)
+
+-- | Verifies that foreign key actions are enforced at runtime.
+foreignKeyActionsWork :: IO ByteString -> TestTree
+foreignKeyActionsWork pgConn =
+    testCase "cascading foreign key actions" $
+      withTestPostgres "db_fk_actions" pgConn $ \conn -> do
+        let db :: CheckedDatabaseSettings Postgres FkDb
+            db = defaultMigratableDbSettings `withDbModification`
+                  (dbModification @_ @Postgres)
+                    { _fk_child =
+                        addTableForeignKey (_fk_parent db)
+                          (foreignKeyColumns _fk_child_parent_id)
+                          primaryKeyColumns
+                          ForeignKeyActionCascade
+                          ForeignKeyActionCascade
+                    }
+            unc = unCheckDatabase db
+        runBeamPostgres conn $ autoMigrate migrationBackend db
+
+        -- Insert two parents and three children (two for parent 1, one for parent 2).
+        runBeamPostgres conn $ do
+          runInsert $ insert (_fk_parent unc) $ insertValues
+            [ FkParentT 1, FkParentT 2 ]
+          runInsert $ insert (_fk_child unc) $ insertValues
+            [ FkChildT 1 (FkParentPk 1), FkChildT 2 (FkParentPk 1), FkChildT 3 (FkParentPk 2) ]
+
+        -- ON UPDATE CASCADE: changing fk_parent_id 1 → 10 should cascade to child rows.
+        runBeamPostgres conn $
+          runUpdate $ update (_fk_parent unc)
+            (\p -> _fk_parent_id p <-. val_ 10)
+            (\p -> _fk_parent_id p ==. val_ 1)
+        childrenOf10 <- runBeamPostgres conn $ runSelectReturningList $ select $
+          filter_ (\c -> let FkParentPk pid = _fk_child_parent_id c in pid ==. val_ 10) $ all_ (_fk_child unc)
+        assertEqual "two children should now reference updated parent id 10"
+          2 (length childrenOf10)
+        childrenOf1 <- runBeamPostgres conn $ runSelectReturningList $ select $
+          filter_ (\c -> let FkParentPk pid = _fk_child_parent_id c in pid ==. val_ 1) $ all_ (_fk_child unc)
+        assertEqual "no children should still reference old parent id 1"
+          0 (length childrenOf1)
+
+        -- ON DELETE CASCADE: deleting parent 2 should remove its child row.
+        runBeamPostgres conn $
+          runDelete $ delete (_fk_parent unc) (\p -> _fk_parent_id p ==. val_ 2)
+        childrenOf2 <- runBeamPostgres conn $ runSelectReturningList $ select $
+          filter_ (\c -> let FkParentPk pid = _fk_child_parent_id c in pid ==. val_ 2) $ all_ (_fk_child unc)
+        assertEqual "child of deleted parent 2 should be removed"
+          0 (length childrenOf2)
+        allChildren <- runBeamPostgres conn $ runSelectReturningList $ select $
+          all_ (_fk_child unc)
+        assertEqual "only the two children of parent 10 should remain"
+          2 (length allChildren)
+
+-- | Verifies that 'verifySchema' correctly detects a foreign key with ON DELETE CASCADE
+foreignKeyOnDeleteCascadeVerification :: IO ByteString -> TestTree
+foreignKeyOnDeleteCascadeVerification pgConn =
+    testCase "verifySchema correctly detects a foreign key with ON DELETE CASCADE" $
+      withTestPostgres "db_fk_cascade" pgConn $ \conn -> do
+        Pg.execute_ conn "CREATE TABLE fk_parent (fk_parent_id integer NOT NULL PRIMARY KEY)"
+        Pg.execute_ conn "CREATE TABLE fk_child  (fk_child_id integer NOT NULL PRIMARY KEY, \
+                         \fk_child_parent_id integer NOT NULL, \
+                         \FOREIGN KEY (fk_child_parent_id) REFERENCES fk_parent (fk_parent_id) \
+                         \ON DELETE CASCADE)"
+        let db :: CheckedDatabaseSettings Postgres FkDb
+            db = defaultMigratableDbSettings `withDbModification`
+                  (dbModification @_ @Postgres)
+                    { _fk_child =
+                        addTableForeignKey (_fk_parent db)
+                          (foreignKeyColumns _fk_child_parent_id)
+                          primaryKeyColumns
+                          ForeignKeyNoAction
+                          ForeignKeyActionCascade
+                        <> modifyCheckedTable id
+                             (FkChildT { _fk_child_id        = "fk_child_id"
+                                       , _fk_child_parent_id = FkParentPk "fk_child_parent_id" }) }
         runBeamPostgres conn (verifySchema migrationBackend db) >>= \case
           VerificationSucceeded -> return ()
           VerificationFailed failures -> fail ("Verification failed: " ++ show failures)

--- a/beam-sqlite/ChangeLog.md
+++ b/beam-sqlite/ChangeLog.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Added features
+
+* `getDbConstraints` now discovers foreign key constraints via `PRAGMA foreign_key_list`, including `ON DELETE` / `ON UPDATE` actions.
+
 # 0.5.7.0
 
 ## Added features

--- a/beam-sqlite/Database/Beam/Sqlite/Migrate.hs
+++ b/beam-sqlite/Database/Beam/Sqlite/Migrate.hs
@@ -40,9 +40,10 @@ import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy.Char8 as BL
 import           Data.Char (isSpace)
 import           Data.Int (Int64)
-import           Data.List (sortBy)
+import           Data.List (sortBy, groupBy)
 import qualified Data.List.NonEmpty as NE (nonEmpty)
 import           Data.Maybe (mapMaybe, isJust)
+import           Data.Function (on)
 import           Data.Monoid (Endo(..))
 import           Data.Ord (comparing)
 import           Data.String (fromString)
@@ -262,8 +263,6 @@ runSqlScript t =
         let hdl = connectionHandle conn
         in exec hdl t
 
--- TODO constraints and foreign keys
-
 -- | Get a list of database predicates for the current database. This is beam's
 -- best guess at providing a schema for the current database. Note that SQLite
 -- type names are not standardized, and the so-called column "affinities" are
@@ -348,10 +347,43 @@ getDbConstraints extraParser =
                       [ Db.SomeDatabasePredicate
                           (Db.TableHasIndex @Sqlite tblName idxNm colsNE opts) ]
 
+        -- Collect foreign key constraints via PRAGMA foreign_key_list.
+        -- Each row: (id, seq, table, from, to, on_update, on_delete, match)
+        -- Rows sharing the same 'id' form a composite foreign key,
+        -- with 'seq' providing the ordering.
+        fkRows <- query_ conn (fromString ("PRAGMA foreign_key_list('" <> T.unpack tblNameStr <> "')")
+                          ) :: IO [(Int, Int, T.Text, T.Text, T.Text, T.Text, T.Text, T.Text)]
+        let fkPreds =
+              concatMap mkFkPred $
+              groupBy ((==) `on` (\(fkId, _, _, _, _, _, _, _) -> fkId)) $
+              sortBy (comparing (\(fkId, seqNo, _, _, _, _, _, _) -> (fkId, seqNo))) fkRows
+            mkFkPred [] = []
+            mkFkPred rows@((_, _, refTblStr, _, _, onUpdateStr, onDeleteStr, _):_) =
+              let localCols = map (\(_, _, _, from, _, _, _, _) -> from) rows
+                  refCols   = map (\(_, _, _, _, to,   _, _, _) -> to)   rows
+                  refTable  = QualifiedName Nothing refTblStr
+                  onUpdate  = parseForeignKeyAction onUpdateStr
+                  onDelete  = parseForeignKeyAction onDeleteStr
+              in case (NE.nonEmpty localCols, NE.nonEmpty refCols) of
+                   (Just lcNE, Just rcNE) ->
+                     [ Db.SomeDatabasePredicate
+                         (Db.TableHasForeignKey tblName lcNE refTable rcNE onUpdate onDelete) ]
+                   _ -> []
+
         pure ( [ Db.SomeDatabasePredicate (Db.TableExistsPredicate tblName) ]
-             ++ pkPred ++ columnPreds ++ idxPreds )
+             ++ pkPred ++ columnPreds ++ idxPreds ++ fkPreds )
 
     pure tblPreds
+
+parseForeignKeyAction :: T.Text -> Db.ForeignKeyAction
+parseForeignKeyAction t = case T.toUpper t of
+  "CASCADE"    -> Db.ForeignKeyActionCascade
+  "SET NULL"   -> Db.ForeignKeyActionSetNull
+  "SET DEFAULT"-> Db.ForeignKeyActionSetDefault
+  "RESTRICT"   -> Db.ForeignKeyActionRestrict
+  "NO ACTION"  -> Db.ForeignKeyNoAction
+  _            -> error $
+    "parseForeignKeyAction: unrecognised foreign key action: " ++ T.unpack t
 
 sqliteText :: Db.DataType Sqlite T.Text
 sqliteText = Db.DataType sqliteTextType

--- a/beam-sqlite/Database/Beam/Sqlite/Syntax.hs
+++ b/beam-sqlite/Database/Beam/Sqlite/Syntax.hs
@@ -65,7 +65,7 @@ import           Data.Coerce
 import qualified Data.DList as DL
 import           Data.Hashable
 import           Data.Int
-import qualified Data.List.NonEmpty as NE (toList)
+import qualified Data.List.NonEmpty as NE (NonEmpty(..), toList)
 import           Data.Maybe
 import           Data.Scientific
 import           Data.String
@@ -282,7 +282,7 @@ data SqliteColumnConstraintSyntax
 data SqliteTableConstraintSyntax
   = SqliteTableConstraintSyntax
   { fromSqliteTableConstraint :: SqliteSyntax
-  , sqliteTableConstraintPrimaryKey :: Maybe [ T.Text ] }
+  , sqliteTableConstraintPrimaryKey :: Maybe (NE.NonEmpty T.Text) }
 data SqliteMatchTypeSyntax
     = SqliteMatchTypeSyntax
     { fromSqliteMatchType :: SqliteSyntax
@@ -476,11 +476,27 @@ instance IsSql92ReferentialActionSyntax SqliteReferentialActionSyntax where
   referentialActionSetDefaultSyntax = SqliteReferentialActionSyntax (emit "SET DEFAULT") referentialActionSetDefaultSyntax
   referentialActionNoActionSyntax = SqliteReferentialActionSyntax (emit "NO ACTION") referentialActionNoActionSyntax
 
+sqliteForeignKeyAction :: ForeignKeyAction -> SqliteSyntax
+sqliteForeignKeyAction ForeignKeyActionCascade    = emit "CASCADE"
+sqliteForeignKeyAction ForeignKeyActionSetNull    = emit "SET NULL"
+sqliteForeignKeyAction ForeignKeyActionSetDefault = emit "SET DEFAULT"
+sqliteForeignKeyAction ForeignKeyActionRestrict   = emit "RESTRICT"
+sqliteForeignKeyAction ForeignKeyNoAction         = emit "NO ACTION"
+
 instance IsSql92TableConstraintSyntax SqliteTableConstraintSyntax where
   primaryKeyConstraintSyntax fields =
     SqliteTableConstraintSyntax
-      (emit "PRIMARY KEY" <> parens (commas (map quotedIdentifier fields)))
+      (emit "PRIMARY KEY" <> parens (commas (map quotedIdentifier $ NE.toList fields)))
       (Just fields)
+  foreignKeyConstraintSyntax localCols refTbl refCols onUpdate onDelete =
+    SqliteTableConstraintSyntax syntax Nothing
+    where
+      syntax =
+        emit "FOREIGN KEY" <> parens (commas (map quotedIdentifier $ NE.toList localCols)) <>
+        emit " REFERENCES " <> quotedIdentifier refTbl <>
+        parens (commas (map quotedIdentifier $ NE.toList refCols)) <>
+        emit " ON UPDATE " <> sqliteForeignKeyAction onUpdate <>
+        emit " ON DELETE " <> sqliteForeignKeyAction onDelete
 
 instance IsSql92CreateTableSyntax SqliteCreateTableSyntax where
   type Sql92CreateTableColumnSchemaSyntax SqliteCreateTableSyntax = SqliteColumnSchemaSyntax
@@ -511,7 +527,7 @@ instance IsSql92CreateTableSyntax SqliteCreateTableSyntax where
          [field] ->
            case constraintPks of
              [] -> error "A column claims to have a primary key, but there is no key on this table"
-             [[fieldPk]]
+             [fieldPk NE.:| _]
                | field /= fieldPk -> error "Two columns claim to be a primary key on this table"
                | otherwise -> createTableNoPkConstraint
              _ -> error "There are multiple primary key constraints on this table"

--- a/beam-sqlite/README.md
+++ b/beam-sqlite/README.md
@@ -10,3 +10,36 @@ see
 Due to SQLite's embedded nature, there are currently no plans to get rid of
 these. However, proposals and PRs to fix these corner cases are welcome, where
 appropriate.
+
+## Migration support
+
+`beam-sqlite` supports schema introspection and verification via
+`Database.Beam.Sqlite.Migrate`, including:
+
+- Tables, columns, and their types,
+- `NOT NULL` constraints,
+- Primary keys,
+- User-created secondary indices (via `PRAGMA index_list` / `PRAGMA index_info`),
+- Foreign key constraints (via `PRAGMA foreign_key_list`), including
+  `ON DELETE` / `ON UPDATE` actions.
+
+### Declaring foreign keys
+
+Use `addTableForeignKey` from `beam-migrate` to declare a foreign key on a
+checked table entity:
+
+```haskell
+let db = defaultMigratableDbSettings `withDbModification`
+          (dbModification @_ @Sqlite)
+            { _orders =
+                addTableForeignKey (_customers db)
+                  (\t -> selectorColumnName _order_customer_id t NE.:| [])
+                  primaryKeyColumns
+                  ForeignKeyNoAction      -- ON UPDATE NO ACTION (default)
+                  ForeignKeyActionCascade -- ON DELETE CASCADE
+            }
+```
+
+> **Note:** SQLite disables foreign key enforcement by default. Issue
+> `PRAGMA foreign_keys = ON` on each connection (or set it in your open hook)
+> to enable it at runtime.

--- a/beam-sqlite/test/Database/Beam/Sqlite/Test/Migrate.hs
+++ b/beam-sqlite/test/Database/Beam/Sqlite/Test/Migrate.hs
@@ -21,6 +21,9 @@ tests = testGroup "Migration tests"
   , verifiesNoPrimaryKey
   , verifiesIndex
   , verifiesUniqueIndex
+  , verifiesForeignKey
+  , verifiesForeignKeyActions
+  , foreignKeyActionsWork
   ]
 
 newtype WithPkT f = WithPkT
@@ -121,3 +124,126 @@ verifiesUniqueIndex = testCase "verifySchema correctly detects a UNIQUE secondar
                     addTableIndex "idx_tbl_value_uniq" idxOpts
                       (\t -> selectorColumnName _idx_value t NE.:| []) }
     testVerifySchema conn db
+
+-- Foreign key tests
+
+data ParentT f = ParentT
+  { _parent_id :: C f Int32
+  } deriving (Generic, Beamable)
+
+instance Table ParentT where
+  newtype PrimaryKey ParentT f = ParentPk (C f Int32)
+    deriving (Generic, Beamable)
+  primaryKey = ParentPk . _parent_id
+
+data ChildT f = ChildT
+  { _child_id        :: C f Int32
+  , _child_parent_id :: PrimaryKey ParentT f
+  } deriving (Generic, Beamable)
+
+instance Table ChildT where
+  newtype PrimaryKey ChildT f = ChildPk (C f Int32)
+    deriving (Generic, Beamable)
+  primaryKey = ChildPk . _child_id
+
+data FkDb entity = FkDb
+  { _fk_parent :: entity (TableEntity ParentT)
+  , _fk_child  :: entity (TableEntity ChildT)
+  } deriving (Generic, Database Sqlite)
+
+verifiesForeignKey :: TestTree
+verifiesForeignKey = testCase "verifySchema detects a plain foreign key" $
+  withTestDb $ \conn -> do
+    execute_ conn "create table fk_parent (parent_id int not null primary key)"
+    execute_ conn "create table fk_child  (child_id int not null primary key, \
+                  \child_parent_id int not null, \
+                  \foreign key (child_parent_id) references fk_parent (parent_id))"
+    let db :: CheckedDatabaseSettings Sqlite FkDb
+        db = defaultMigratableDbSettings `withDbModification`
+              (dbModification @_ @Sqlite)
+                { _fk_child =
+                    addTableForeignKey (_fk_parent db)
+                      (foreignKeyColumns _child_parent_id)
+                      primaryKeyColumns
+                      ForeignKeyNoAction
+                      ForeignKeyNoAction
+                    <> modifyCheckedTable id
+                         (ChildT { _child_id        = "child_id"
+                                 , _child_parent_id = ParentPk "child_parent_id" }) }
+    testVerifySchema conn db
+
+verifiesForeignKeyActions :: TestTree
+verifiesForeignKeyActions =
+  testCase "verifySchema detects a foreign key with ON DELETE & ON UPDATE actions" $
+  withTestDb $ \conn -> do
+    execute_ conn "create table fk_parent (parent_id int not null primary key)"
+    execute_ conn "create table fk_child  (child_id int not null primary key, \
+                  \child_parent_id int not null, \
+                  \foreign key (child_parent_id) references fk_parent (parent_id) \
+                  \on delete cascade on update restrict)"
+    let db :: CheckedDatabaseSettings Sqlite FkDb
+        db = defaultMigratableDbSettings `withDbModification`
+              (dbModification @_ @Sqlite)
+                { _fk_child =
+                    addTableForeignKey (_fk_parent db)
+                      (foreignKeyColumns _child_parent_id)
+                      primaryKeyColumns
+                      ForeignKeyActionRestrict
+                      ForeignKeyActionCascade
+                    <> modifyCheckedTable id
+                         (ChildT { _child_id        = "child_id"
+                                 , _child_parent_id = ParentPk "child_parent_id" }) }
+    testVerifySchema conn db
+
+-- | Verifies that foreign key actions are enforced at runtime.
+foreignKeyActionsWork :: TestTree
+foreignKeyActionsWork =
+  testCase "foreign key actions" $
+  withTestDb $ \conn -> do
+    -- Enable foreign key support (required for SQLite)
+    execute_ conn "PRAGMA foreign_keys = ON"
+    let db :: CheckedDatabaseSettings Sqlite FkDb
+        db = defaultMigratableDbSettings `withDbModification`
+              (dbModification @_ @Sqlite)
+                { _fk_child =
+                    addTableForeignKey (_fk_parent db)
+                      (foreignKeyColumns _child_parent_id)
+                      primaryKeyColumns
+                      ForeignKeyActionCascade
+                      ForeignKeyActionCascade
+                }
+        unc = unCheckDatabase db
+    runBeamSqlite conn $ autoMigrate migrationBackend db
+
+    -- Insert two parents and three children (two for parent 1, one for parent 2).
+    runBeamSqlite conn $ do
+      runInsert $ insert (_fk_parent unc) $ insertValues
+        [ ParentT 1, ParentT 2 ]
+      runInsert $ insert (_fk_child unc) $ insertValues
+        [ ChildT 1 (ParentPk 1), ChildT 2 (ParentPk 1), ChildT 3 (ParentPk 2) ]
+
+    -- ON UPDATE CASCADE: changing parent_id 1 → 10 should cascade to child rows.
+    runBeamSqlite conn $
+      runUpdate $ update (_fk_parent unc)
+        (\p -> _parent_id p <-. val_ 10)
+        (\p -> _parent_id p ==. val_ 1)
+    childrenOf10 <- runBeamSqlite conn $ runSelectReturningList $ select $
+      filter_ (\c -> let ParentPk pid = _child_parent_id c in pid ==. val_ 10) $ all_ (_fk_child unc)
+    assertEqual "two children should now reference updated parent id 10"
+      2 (length childrenOf10)
+    childrenOf1 <- runBeamSqlite conn $ runSelectReturningList $ select $
+      filter_ (\c -> let ParentPk pid = _child_parent_id c in pid ==. val_ 1) $ all_ (_fk_child unc)
+    assertEqual "no children should still reference old parent id 1"
+      0 (length childrenOf1)
+
+    -- ON DELETE CASCADE: deleting parent 2 should remove its child row.
+    runBeamSqlite conn $
+      runDelete $ delete (_fk_parent unc) (\p -> _parent_id p ==. val_ 2)
+    childrenOf2 <- runBeamSqlite conn $ runSelectReturningList $ select $
+      filter_ (\c -> let ParentPk pid = _child_parent_id c in pid ==. val_ 2) $ all_ (_fk_child unc)
+    assertEqual "child of deleted parent 2 should be removed"
+      0 (length childrenOf2)
+    allChildren <- runBeamSqlite conn $ runSelectReturningList $ select $
+      all_ (_fk_child unc)
+    assertEqual "only the two children of parent 10 should remain"
+      2 (length allChildren)


### PR DESCRIPTION
This PR adds support for foreign key constraints and actions to `beam-migrate`, with support in the Postgres and SQLite backends.

  - The `ForeignKeyAction` datatype is used to represent possible actions to perform when updating or deleting a row with referencing foreign keys.
  - `createTableActionProvider` now takes an additional `ForeignKeySupport` argument: a witness of evidence for `IsSql92ForeignKeyTableConstraintSyntax` for backends that support it.
  - Postgres and SQLite support for parsing existing foreign key constraints.
  - The function `addTableForeignKey` can be used to declare new foreign key constraints.