### PR TITLE
Fixes to beam-migrate solving

### DIFF
--- a/beam-migrate/ChangeLog.md
+++ b/beam-migrate/ChangeLog.md
@@ -16,6 +16,9 @@
 * Fix an issue in which `beam-migrate` would fail to migrate a unique index
   to a non-unique index or vice-versa.
 
+* Fixed an issue in which the migration solver could end up taking an
+  exponentially long time to conclude that migration isn't possible.
+
 # 0.5.4.0
 
 ## Added features

--- a/beam-migrate/ChangeLog.md
+++ b/beam-migrate/ChangeLog.md
@@ -11,6 +11,11 @@
     `foreignKeyConstraintSyntax`, for constructing foreign key constraint syntax.
   * Introduce `addTableForeignKey` for declaring new foreign key constraints.
 
+## Bug fixes
+
+* Fix an issue in which `beam-migrate` would fail to migrate a unique index
+  to a non-unique index or vice-versa.
+
 # 0.5.4.0
 
 ## Added features

--- a/beam-migrate/Database/Beam/Migrate/Actions.hs
+++ b/beam-migrate/Database/Beam/Migrate/Actions.hs
@@ -486,16 +486,14 @@ dropColumnProvider :: forall be
 dropColumnProvider = ActionProvider provider
   where
     provider :: ActionProviderFn be
-    provider findPreConditions _ =
+    provider findPreConditions findPostConditions =
       do colP@(TableHasColumn tblNm colNm _ :: TableHasColumn be)
            <- findPreConditions
 
---         TableExistsPredicate tblNm' <- trace ("COnsider drop " <> show tblNm <> " " <> show colNm)  findPreConditions
---         guard (any (\(TableExistsPredicate tblNm') -> tblNm' == tblNm) findPreConditions) --tblNm' == tblNm)
---         ensuringNot_ $ do
---           TableHasColumn tblNm' colNm' colType' :: TableHasColumn (Sql92DdlCommandColumnSchemaSyntax cmd) <-
---             findPostConditions
---           guard (tblNm' == tblNm && colNm == colNm' && colType == colType') -- This column exists as a different type
+         -- Don't drop a column that the goal still requires with the same type.
+         ensuringNot_ $ do
+           (colPost :: TableHasColumn be) <- findPostConditions
+           guard (p colPost == p colP)
 
          relatedPreds <- --pure []
            pure $ do p'@(SomeDatabasePredicate pred') <- findPreConditions
@@ -539,10 +537,15 @@ dropColumnNullProvider :: forall be
 dropColumnNullProvider = ActionProvider provider
   where
     provider :: ActionProviderFn be
-    provider findPreConditions _ =
+    provider findPreConditions findPostConditions =
       do colP@(TableColumnHasConstraint tblNm colNm _ :: TableColumnHasConstraint be)
            <- findPreConditions
 -- TODO         guard (c == notNullConstraintSyntax)
+
+         -- Don't drop a constraint that is still required in the goal.
+         ensuringNot_ $
+           do (sdp :: SomeDatabasePredicate) <- findPostConditions
+              guard (sdp == p colP)
 
          TableExistsPredicate tblNm' <- findPreConditions
          guard (tblNm == tblNm')

--- a/beam-migrate/Database/Beam/Migrate/Actions.hs
+++ b/beam-migrate/Database/Beam/Migrate/Actions.hs
@@ -597,10 +597,15 @@ dropIndexActionProvider = ActionProvider provider
     provider findPreConditions findPostConditions =
       do (idxP@(TableHasIndex { hasIndex_table = preTblNm, hasIndex_name = idxNm })
             :: TableHasIndex be) <- findPreConditions
+
+         -- Supress DROP INDEX if the exact same index is still required
+         -- in the goal (including options such as uniqueness).
+         --
+         -- Comparing only by name would wrongly prevent dropping a non-unique
+         -- index that must be replaced by a unique one (or vice-versa).
          ensuringNot_ $
-           do (TableHasIndex { hasIndex_table = postTblNm, hasIndex_name = idxNm' }
-                :: TableHasIndex be) <- findPostConditions
-              guard (preTblNm == postTblNm && idxNm' == idxNm)
+           do (postIdx :: TableHasIndex be) <- findPostConditions
+              guard (p postIdx == p idxP)
 
          let cmd = dropIndexCmd idxNm
          pure (PotentialAction (HS.singleton (p idxP)) mempty

--- a/beam-sqlite/test/Database/Beam/Sqlite/Test/Migrate.hs
+++ b/beam-sqlite/test/Database/Beam/Sqlite/Test/Migrate.hs
@@ -1,5 +1,7 @@
 module Database.Beam.Sqlite.Test.Migrate (tests) where
 
+import Control.Exception (try, IOException)
+import Data.List (isInfixOf)
 import Database.SQLite.Simple
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -23,6 +25,7 @@ tests = testGroup "Migration tests"
   , verifiesUniqueIndex
   , migrateNonUniqueToUniqueIndex
   , verifiesForeignKey
+  , addingForeignKeyFails
   , verifiesForeignKeyActions
   , foreignKeyActionsWork
   ]
@@ -197,6 +200,74 @@ verifiesForeignKey = testCase "verifySchema detects a plain foreign key" $
                          (ChildT { _child_id        = "child_id"
                                  , _child_parent_id = ParentPk "child_parent_id" }) }
     testVerifySchema conn db
+
+-- Schema used to test solver behaviour when a foreign key migration is impossible.
+-- Needs to be somewhat large to trigger the exponential blowup in search space.
+
+data WideParentT f = WideParentT
+  { _wp_id :: C f Int32
+  , _wp_a  :: C f Int32
+  , _wp_b  :: C f Int32
+  , _wp_c  :: C f Int32
+  , _wp_d  :: C f Int32
+  } deriving (Generic, Beamable)
+
+instance Table WideParentT where
+  newtype PrimaryKey WideParentT f = WideParentPk (C f Int32)
+    deriving (Generic, Beamable)
+  primaryKey = WideParentPk . _wp_id
+
+data WideChildT f = WideChildT
+  { _wc_id        :: C f Int32
+  , _wc_parent_id :: PrimaryKey WideParentT f
+  , _wc_a         :: C f Int32
+  , _wc_b         :: C f Int32
+  , _wc_c         :: C f Int32
+  , _wc_d         :: C f Int32
+  } deriving (Generic, Beamable)
+
+instance Table WideChildT where
+  newtype PrimaryKey WideChildT f = WideChildPk (C f Int32)
+    deriving (Generic, Beamable)
+  primaryKey = WideChildPk . _wc_id
+
+data WideFkDb entity = WideFkDb
+  { _wide_parent :: entity (TableEntity WideParentT)
+  , _wide_child  :: entity (TableEntity WideChildT)
+  } deriving (Generic, Database Sqlite)
+
+-- | Check that the solver doesn't grow an enormous search space trying to find
+-- a way to add a foreign key constraint (which SQLite cannot do to an existing
+-- table).
+addingForeignKeyFails :: TestTree
+addingForeignKeyFails =
+  testCase "autoMigrate fails promptly when asked to add a foreign key" $
+  withTestDb $ \conn -> do
+    let noFk :: CheckedDatabaseSettings Sqlite WideFkDb
+        noFk = defaultMigratableDbSettings
+        withFk :: CheckedDatabaseSettings Sqlite WideFkDb
+        withFk = noFk `withDbModification`
+                   (dbModification @_ @Sqlite)
+                     { _wide_child =
+                         addTableForeignKey (_wide_parent withFk)
+                           (foreignKeyColumns _wc_parent_id)
+                           primaryKeyColumns
+                           ForeignKeyNoAction
+                           ForeignKeyNoAction }
+    runBeamSqlite conn $ autoMigrate migrationBackend noFk
+    result <- try @IOException (runBeamSqlite conn $ autoMigrate migrationBackend withFk)
+    case result of
+      Left e
+        | "Could not determine migration" `isInfixOf` show e
+        -> return ()
+      Left e  -> assertFailure $ unlines
+        [ "unexpected exception from autoMigrate:"
+        , "  - " ++ show e
+        ]
+      Right _ -> assertFailure $ unlines
+        [ "expected autoMigrate to fail:"
+        , "  SQLite cannot add foreign key constraints to existing tables"
+        ]
 
 verifiesForeignKeyActions :: TestTree
 verifiesForeignKeyActions =

--- a/beam-sqlite/test/Database/Beam/Sqlite/Test/Migrate.hs
+++ b/beam-sqlite/test/Database/Beam/Sqlite/Test/Migrate.hs
@@ -21,6 +21,7 @@ tests = testGroup "Migration tests"
   , verifiesNoPrimaryKey
   , verifiesIndex
   , verifiesUniqueIndex
+  , migrateNonUniqueToUniqueIndex
   , verifiesForeignKey
   , verifiesForeignKeyActions
   , foreignKeyActionsWork
@@ -124,6 +125,31 @@ verifiesUniqueIndex = testCase "verifySchema correctly detects a UNIQUE secondar
                     addTableIndex "idx_tbl_value_uniq" idxOpts
                       (\t -> selectorColumnName _idx_value t NE.:| []) }
     testVerifySchema conn db
+
+-- | Check that we can change the uniqueness of an index in a migration
+migrateNonUniqueToUniqueIndex :: TestTree
+migrateNonUniqueToUniqueIndex =
+  testCase "autoMigrate can change a non-unique index to a unique index" $
+  withTestDb $ \conn -> do
+    let nonUnique :: CheckedDatabaseSettings Sqlite IdxDb
+        nonUnique =
+          defaultMigratableDbSettings `withDbModification`
+            (dbModification @_ @Sqlite)
+              { _idx_tbl =
+                  addTableIndex "idx_tbl_value"
+                    (defaultIndexOptions @SqliteCommandSyntax)
+                    (\t -> selectorColumnName _idx_value t NE.:| []) }
+        unique :: CheckedDatabaseSettings Sqlite IdxDb
+        unique =
+          defaultMigratableDbSettings `withDbModification`
+            (dbModification @_ @Sqlite)
+              { _idx_tbl =
+                  addTableIndex "idx_tbl_value"
+                    (setUniqueIndexOptions @SqliteCommandSyntax True $
+                     defaultIndexOptions @SqliteCommandSyntax)
+                    (\t -> selectorColumnName _idx_value t NE.:| []) }
+    runBeamSqlite conn $ autoMigrate migrationBackend nonUnique
+    runBeamSqlite conn $ autoMigrate migrationBackend unique
 
 -- Foreign key tests
 


### PR DESCRIPTION
I found out that my changes to indices and foreign keys could cause issues with the migration solver:

  - For indices, beam-migrate would fail to make a unique index into a non-unique index, or vice-versa. That's fixed in the first commit.
  - For mismatches in foreign keys constraints, with SQLite we are in a bit of a bind because there is no ALTER TABLE ADD CONSTRAINT functionality available. So we just want the solver to fail to find a migration. It was not doing so because the solver was endlessly trying to drop columns to try to move closer to the goal, even though it was never helpful. So the second commit adds some quick checks to avoid trying migration steps that drop columns that we want in the goal, as this makes the search space grow (which makes the solver basically run forever).
