### PR TITLE
Don't try to migrate SQLite internal tables

### DIFF
--- a/beam-sqlite/ChangeLog.md
+++ b/beam-sqlite/ChangeLog.md
@@ -4,6 +4,11 @@
 
 * `getDbConstraints` now discovers foreign key constraints via `PRAGMA foreign_key_list`, including `ON DELETE` / `ON UPDATE` actions.
 
+## Bug fixes
+
+* The SQLite migration framework no longer incorrectly concludes a migration
+  would lose data due to the presence of internal `sqlite_*` tables.
+
 # 0.5.7.0
 
 ## Added features

--- a/beam-sqlite/Database/Beam/Sqlite/Migrate.hs
+++ b/beam-sqlite/Database/Beam/Sqlite/Migrate.hs
@@ -274,7 +274,20 @@ runSqlScript t =
 getDbConstraints :: A.Parser SqliteDataTypeSyntax -> SqliteM [Db.SomeDatabasePredicate]
 getDbConstraints extraParser =
   SqliteM . ReaderT $ \(_, conn) -> do
-    tblNames <- query_ conn "SELECT name, sql from sqlite_master where type='table'"
+    -- Exclude SQLite-internal tables (sqlite_sequence, sqlite_stat1, etc.).
+    -- These are created automatically by SQLite (e.g. sqlite_sequence appears
+    -- whenever any table uses AUTOINCREMENT).
+    --
+    -- Failing to filter them out would mean we would try to drop them, which
+    -- would incorrectly look like data loss.
+    --
+    -- NB: (https://www.sqlite.org/lang_createtable.html)
+    --
+    --   Table names that begin with "sqlite_" are reserved for internal use.
+    --   It is an error to attempt to create a table with a name that starts with "sqlite_".
+    tblNames <-
+      query_ conn
+        "SELECT name, sql FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite\\_%' ESCAPE '\\'"
     tblPreds <-
       fmap mconcat . forM tblNames $ \(tblNameStr, sql) -> do
         let tblName = QualifiedName Nothing tblNameStr

--- a/beam-sqlite/test/Database/Beam/Sqlite/Test/Migrate.hs
+++ b/beam-sqlite/test/Database/Beam/Sqlite/Test/Migrate.hs
@@ -7,6 +7,7 @@ import Test.Tasty.HUnit
 import qualified Data.List.NonEmpty as NE
 import Data.Int (Int32)
 import Database.Beam
+import Database.Beam.Backend.SQL.BeamExtensions (SqlSerial(..))
 import Database.Beam.Sqlite
 import Database.Beam.Sqlite.Migrate
 import Database.Beam.Migrate
@@ -24,6 +25,7 @@ tests = testGroup "Migration tests"
   , verifiesForeignKey
   , verifiesForeignKeyActions
   , foreignKeyActionsWork
+  , idempotentMigration
   ]
 
 newtype WithPkT f = WithPkT
@@ -247,3 +249,35 @@ foreignKeyActionsWork =
       all_ (_fk_child unc)
     assertEqual "only the two children of parent 10 should remain"
       2 (length allChildren)
+
+--------------------------------------------------------------------------------
+-- Ensure migration is idempotent (no data loss due to internal tables)
+
+data SimpleT f = SimpleT
+  { _auto_incr_id :: C f (SqlSerial Int32)
+  } deriving (Generic, Beamable)
+
+instance Table SimpleT where
+  newtype PrimaryKey SimpleT f = AutoIncrPk (C f (SqlSerial Int32))
+    deriving (Generic, Beamable)
+  primaryKey = AutoIncrPk . _auto_incr_id
+
+data SimpleDb entity = SimpleDb
+  { _simple_tbl :: entity (TableEntity SimpleT)
+  } deriving (Generic, Database Sqlite)
+
+simpleCheckedDb :: CheckedDatabaseSettings Sqlite SimpleDb
+simpleCheckedDb = defaultMigratableDbSettings
+
+idempotentMigration :: TestTree
+idempotentMigration =
+  testCase "autoMigrate is idempotent" $
+  withTestDb $ \conn -> do
+    runBeamSqlite conn $ autoMigrate migrationBackend simpleCheckedDb
+    -- Insert a row so that sqlite_sequence is populated in sqlite_master.
+    execute_ conn "INSERT INTO simple_tbl DEFAULT VALUES"
+    -- Make sure we don't think a migration would lose data due to the
+    -- presence of the sqlite_sequence table.
+    runBeamSqlite conn $ autoMigrate migrationBackend simpleCheckedDb
+
+--------------------------------------------------------------------------------


### PR DESCRIPTION
The SQLite migration backend incorrectly took into account internal SQLite tables (e.g. sqlite_sequence). It would then try to drop them, making even trivial migrations look like they lose data.

The fix is simple: just filter out SQLite internal tables; they start with `sqlite_` (which is reserved for internal SQLite tables as per the SQLite documentation).