### PR TITLE
Add support for temporary tables

### DIFF
--- a/beam-core/ChangeLog.md
+++ b/beam-core/ChangeLog.md
@@ -4,6 +4,13 @@
 
 * Updated the upper bound on `time` to include `time-1.14`
 
+## Query combinator API change
+
+* The `Database be db` context has been removed from the query combinators `all_`,
+  `allFromView_`, `join_`, `join'`, `related_`, `relatedBy_` and `relatedBy_'`.
+
+  This constraint was not used by any of these functions.
+
 # 0.10.4.0
 
 ## Added features

--- a/beam-core/Database/Beam/Query/Combinators.hs
+++ b/beam-core/Database/Beam/Query/Combinators.hs
@@ -88,19 +88,18 @@ import Unsafe.Coerce (unsafeCoerce)
 import GHC.TypeLits (TypeError, ErrorMessage(Text))
 
 -- | Introduce all entries of a table into the 'Q' monad
-all_ :: ( Database be db, BeamSqlBackend be )
-       => DatabaseEntity be db (TableEntity table)
-       -> Q be db s (table (QExpr be s))
+all_ :: BeamSqlBackend be
+     => DatabaseEntity be db (TableEntity table)
+     -> Q be db s (table (QExpr be s))
 all_ (DatabaseEntity dt@(DatabaseTable {})) =
     Q $ liftF (QAll (\_ -> fromTable (tableNamed (tableName (dbTableSchema dt) (dbTableCurrentName dt))) . Just . (,Nothing))
                     (tableFieldsToExpressions (dbTableSettings dt))
                     (\_ -> Nothing) snd)
 
 -- | Introduce all entries of a view into the 'Q' monad
-allFromView_ :: ( Database be db, Beamable table
-                , BeamSqlBackend be )
-               => DatabaseEntity be db (ViewEntity table)
-               -> Q be db s (table (QExpr be s))
+allFromView_ :: ( Beamable table, BeamSqlBackend be )
+             => DatabaseEntity be db (ViewEntity table)
+             -> Q be db s (table (QExpr be s))
 allFromView_ (DatabaseEntity vw) =
     Q $ liftF (QAll (\_ -> fromTable (tableNamed (tableName (dbViewSchema vw) (dbViewCurrentName vw))) . Just . (,Nothing))
                     (tableFieldsToExpressions (dbViewSettings vw))
@@ -124,7 +123,7 @@ values_ rows =
 --   'Bool'. For a version that takes 'SqlBool' (a possibly @UNKNOWN@
 --   boolean, that maps more closely to the SQL standard), see
 --   'join_''.
-join_ :: ( Database be db, Table table, BeamSqlBackend be )
+join_ :: ( Table table, BeamSqlBackend be )
       => DatabaseEntity be db (TableEntity table)
       -> (table (QExpr be s) -> QExpr be s Bool)
       -> Q be db s (table (QExpr be s))
@@ -132,7 +131,7 @@ join_ tbl mkOn = join_' tbl (sqlBool_ . mkOn)
 
 -- | Like 'join_', but accepting an @ON@ condition that returns
 -- 'SqlBool'
-join_' :: ( Database be db, Table table, BeamSqlBackend be )
+join_' :: ( Table table, BeamSqlBackend be )
        => DatabaseEntity be db (TableEntity table)
        -> (table (QExpr be s) -> QExpr be s SqlBool)
        -> Q be db s (table (QExpr be s))
@@ -282,7 +281,7 @@ filter_' mkExpr clause = clause >>= \x -> guard_' (mkExpr x) >> pure x
 
 -- | Introduce all entries of the given table which are referenced by the given 'PrimaryKey'
 related_ :: forall be db rel s
-          . ( Database be db, Table rel, BeamSqlBackend be
+          . ( Table rel, BeamSqlBackend be
             , HasTableEquality be (PrimaryKey rel)
             )
          => DatabaseEntity be db (TableEntity rel)
@@ -293,7 +292,7 @@ related_ relTbl relKey =
 
 -- | Introduce all entries of the given table for which the expression (which can depend on the queried table returns true)
 relatedBy_ :: forall be db rel s
-            . ( Database be db, Table rel, BeamSqlBackend be )
+            . ( Table rel, BeamSqlBackend be )
            => DatabaseEntity be db (TableEntity rel)
            -> (rel (QExpr be s) -> QExpr be s Bool)
            -> Q be db s (rel (QExpr be s))
@@ -301,7 +300,7 @@ relatedBy_ = join_
 
 -- | Introduce all entries of the given table for which the expression (which can depend on the queried table returns true)
 relatedBy_' :: forall be db rel s
-             . ( Database be db, Table rel, BeamSqlBackend be )
+             . ( Table rel, BeamSqlBackend be )
             => DatabaseEntity be db (TableEntity rel)
             -> (rel (QExpr be s) -> QExpr be s SqlBool)
             -> Q be db s (rel (QExpr be s))

--- a/beam-migrate/ChangeLog.md
+++ b/beam-migrate/ChangeLog.md
@@ -11,6 +11,13 @@
     `foreignKeyConstraintSyntax`, for constructing foreign key constraint syntax.
   * Introduce `addTableForeignKey` for declaring new foreign key constraints.
 
+* Added support for temporary tables:
+
+  * The `BeamHasTempTables` typeclass is used for backends to emit
+    `CREATE TEMPORARY TABLE` syntax.
+  * The `runCreateTempTable` command allows creating a temporary table.
+    The returned table entity can be used in queries like any other table.
+
 ## Bug fixes
 
 * Fix an issue in which `beam-migrate` would fail to migrate a unique index

--- a/beam-migrate/Database/Beam/Migrate/TempTable.hs
+++ b/beam-migrate/Database/Beam/Migrate/TempTable.hs
@@ -1,0 +1,247 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Database.Beam.Migrate.TempTable
+  ( -- * Temporary tables
+
+    -- ** @CREATE TEMPORARY TABLE@
+    runCreateTempTable
+
+    -- ** Options
+  , TempTableCreateMode(..)
+  , TempTableOptions(..)
+  , defaultTempTableOptions
+
+    -- ** Backend support for temporary tables
+  , BeamHasTempTables(..)
+
+    -- ** Schema constraint
+  , HasDefaultTempTableSchema
+
+    -- ** Internals
+  , GNullableConstraintsForSchema(..)
+  , GDefaultBackendFieldSchemas(..)
+  ) where
+
+import           Control.Monad.Writer (execWriter, tell)
+
+import           Data.Functor.Const (Const(..))
+import           Data.Functor.Identity (Identity(..))
+import           Data.Kind (Type)
+import           Data.Proxy (Proxy(..))
+import qualified Data.Text as T
+import           GHC.Generics
+
+import           Database.Beam.Backend.SQL
+  ( MonadBeam(..), BeamSqlBackendSyntax )
+import           Database.Beam.Backend.Types (Nullable)
+import           Database.Beam.Migrate.Generics (HasDefaultSqlDataType(..), NullableStatus)
+import           Database.Beam.Migrate.SQL.SQL92
+  ( IsSql92ColumnSchemaSyntax(..)
+  , IsSql92ColumnConstraintDefinitionSyntax(..)
+  , IsSql92ColumnConstraintSyntax(..)
+  )
+import           Database.Beam.Migrate.SQL.Types
+  ( BeamMigrateSqlBackend
+  , BeamSqlBackendColumnSchemaSyntax
+  , BeamSqlBackendColumnConstraintDefinitionSyntax
+  )
+import           Database.Beam.Query (HasQBuilder)
+import           Database.Beam.Schema.Tables
+  ( DatabaseEntity(..), DatabaseEntityDescriptor(..)
+  , TableEntity
+  , TableSettings, TableField(..)
+  , defTblFieldSettings, allBeamValues, zipBeamFieldsM
+  , Columnar'(..), Table(..)
+  , GDefaultTableFieldSettings
+  )
+
+--------------------------------------------------------------------------------
+
+-- | How to handle an existing temporary table when calling 'runCreateTempTable'.
+data TempTableCreateMode
+  = CreateIfNotExists
+    -- ^ Emit @CREATE TEMPORARY TABLE IF NOT EXISTS@.
+    -- If the table already exists, do nothing.
+  | DropAndCreate
+    -- ^ Emit @DROP TABLE IF EXISTS@ followed by @CREATE TEMPORARY TABLE@.
+    -- The table is always (re)created fresh.
+  deriving (Eq, Ord, Show)
+
+-- | Options for 'runCreateTempTable'.
+data TempTableOptions = TempTableOptions
+  { tempTableCreateMode :: TempTableCreateMode
+    -- ^ Whether to preserve an existing table or recreate it from scratch.
+  }
+
+-- | Default options: use @CREATE TEMPORARY TABLE IF NOT EXISTS@.
+defaultTempTableOptions :: TempTableOptions
+defaultTempTableOptions =
+  TempTableOptions { tempTableCreateMode = CreateIfNotExists }
+
+-- | Support for temporary tables in a Beam backend.
+class (BeamMigrateSqlBackend be, HasQBuilder be) => BeamHasTempTables be where
+  -- | Render a @CREATE TEMPORARY TABLE@ command.
+  createTempTableCmd
+    :: T.Text
+       -- ^ table name
+    -> [(T.Text, BeamSqlBackendColumnSchemaSyntax be)]
+       -- ^ ordered (column name, column schema) pairs
+    -> [T.Text]
+       -- ^ primary key column names (empty for no primary key constraint)
+    -> Bool
+       -- ^ include @IF NOT EXISTS@?
+    -> BeamSqlBackendSyntax be
+
+  -- | Render a @DROP TABLE IF EXISTS@ command.
+  dropTempTableIfExistsCmd
+    :: T.Text
+       -- ^ table name
+    -> BeamSqlBackendSyntax be
+
+
+-- | Constraint used for deriving the schema of a temporary table.
+type HasDefaultTempTableSchema be tbl =
+  ( BeamHasTempTables be
+  , Generic (tbl (Const (BeamSqlBackendColumnSchemaSyntax be)))
+  , GDefaultBackendFieldSchemas be
+      (Rep (tbl Identity))
+      (Rep (tbl (Const (BeamSqlBackendColumnSchemaSyntax be))))
+  , Table tbl
+  , Generic (TableSettings tbl)
+  , GDefaultTableFieldSettings (Rep (TableSettings tbl) ())
+  )
+
+-- ---------------------------------------------------------------------------
+-- CREATE TEMPORARY TABLE
+
+-- | Execute @CREATE TEMPORARY TABLE@, returning the created temporary table
+-- entity.
+--
+-- Note that the @db@ parameter is phantom; if you need to change it you can
+-- use 'Data.Coerce.coerce'.
+runCreateTempTable
+  :: forall be db tbl m
+  .  ( HasDefaultTempTableSchema be tbl
+     , MonadBeam be m )
+  => TempTableOptions
+  -> T.Text -- ^ temporary table name
+  -> m (DatabaseEntity be db (TableEntity tbl))
+runCreateTempTable opts nm = do
+  let tblSettings = defTblFieldSettings :: TableSettings tbl
+      colSchemas  = deriveTblColSchemas (Proxy @be) (Proxy @tbl)
+
+      -- Collect (columnName, columnSchema) pairs in field declaration order.
+      fieldDefs :: [(T.Text, BeamSqlBackendColumnSchemaSyntax be)]
+      fieldDefs = execWriter $
+        zipBeamFieldsM
+          (\(Columnar' tf) c@(Columnar' (Const schema)) ->
+              do tell [(_fieldName tf, schema)]
+                 return c
+          )
+          tblSettings colSchemas
+
+      pkFields =
+        allBeamValues (\(Columnar' tf) -> _fieldName tf) (primaryKey tblSettings)
+
+  case tempTableCreateMode opts of
+    CreateIfNotExists ->
+      runNoReturn (createTempTableCmd @be nm fieldDefs pkFields True)
+    DropAndCreate -> do
+      runNoReturn (dropTempTableIfExistsCmd @be nm)
+      runNoReturn (createTempTableCmd @be nm fieldDefs pkFields False)
+
+  let entity = DatabaseEntity $ DatabaseTable
+        { dbTableSchema      = Nothing
+        , dbTableOrigName    = nm
+        , dbTableCurrentName = nm
+        , dbTableSettings    = tblSettings
+        }
+  pure entity
+
+deriveTblColSchemas
+  :: forall be tbl
+  .  HasDefaultTempTableSchema be tbl
+  => Proxy be -> Proxy tbl -> tbl (Const (BeamSqlBackendColumnSchemaSyntax be))
+deriveTblColSchemas pBe _ =
+  to $ gDefaultBackendFieldSchemas pBe (Proxy @(Rep (tbl Identity))) False
+
+------------------------------------------------------------------------------
+-- Generics machinery (internal)
+
+class BeamMigrateSqlBackend be
+    => GNullableConstraintsForSchema (nullable :: Bool) be where
+  nullableConstraintsForSchema
+    :: Proxy nullable
+    -> Proxy be
+    -> [BeamSqlBackendColumnConstraintDefinitionSyntax be]
+
+instance BeamMigrateSqlBackend be
+    => GNullableConstraintsForSchema 'False be where
+  nullableConstraintsForSchema _ _ =
+    [ constraintDefinitionSyntax Nothing notNullConstraintSyntax Nothing ]
+
+instance BeamMigrateSqlBackend be
+    => GNullableConstraintsForSchema 'True be where
+  nullableConstraintsForSchema _ _ = []
+
+class BeamMigrateSqlBackend be
+    => GDefaultBackendFieldSchemas be (i :: Type -> Type) (o :: Type -> Type) where
+  gDefaultBackendFieldSchemas :: Proxy be -> Proxy i -> Bool -> o ()
+
+instance ( BeamMigrateSqlBackend be
+         , GDefaultBackendFieldSchemas be xId schemaId )
+    => GDefaultBackendFieldSchemas be (M1 t s xId) (M1 t s schemaId) where
+  gDefaultBackendFieldSchemas pBe _ embedded =
+    M1 (gDefaultBackendFieldSchemas pBe (Proxy @xId) embedded)
+
+instance ( BeamMigrateSqlBackend be
+         , GDefaultBackendFieldSchemas be aId aSchema
+         , GDefaultBackendFieldSchemas be bId bSchema )
+    => GDefaultBackendFieldSchemas be (aId :*: bId) (aSchema :*: bSchema) where
+  gDefaultBackendFieldSchemas pBe _ embedded =
+    gDefaultBackendFieldSchemas pBe (Proxy @aId) embedded :*:
+    gDefaultBackendFieldSchemas pBe (Proxy @bId) embedded
+
+
+instance ( HasDefaultSqlDataType be haskTy
+         , GNullableConstraintsForSchema (NullableStatus haskTy) be
+         , cs ~ BeamSqlBackendColumnSchemaSyntax be )
+    => GDefaultBackendFieldSchemas be
+         (Rec0 haskTy)
+         (Rec0 (Const cs haskTy)) where
+  gDefaultBackendFieldSchemas pBe _ embedded =
+    K1 $ Const $ columnSchemaSyntax
+      (defaultSqlDataType (Proxy @haskTy) pBe embedded)
+      Nothing
+      (nullableConstraintsForSchema (Proxy @(NullableStatus haskTy)) pBe)
+      Nothing
+
+instance ( BeamMigrateSqlBackend be
+         , cs ~ BeamSqlBackendColumnSchemaSyntax be
+         , Generic (embeddedTbl (Const cs))
+         , GDefaultBackendFieldSchemas be
+             (Rep (embeddedTbl Identity))
+             (Rep (embeddedTbl (Const cs))) )
+    => GDefaultBackendFieldSchemas be
+         (Rec0 (embeddedTbl Identity))
+         (Rec0 (embeddedTbl (Const cs))) where
+  gDefaultBackendFieldSchemas pBe _ _ =
+    K1 $ to $ gDefaultBackendFieldSchemas pBe
+      (Proxy @(Rep (embeddedTbl Identity))) True
+
+instance ( BeamMigrateSqlBackend be
+         , cs ~ BeamSqlBackendColumnSchemaSyntax be
+         , Generic (embeddedTbl (Nullable (Const cs)))
+         , GDefaultBackendFieldSchemas be
+             (Rep (embeddedTbl (Nullable Identity)))
+             (Rep (embeddedTbl (Nullable (Const cs)))) )
+    => GDefaultBackendFieldSchemas be
+         (Rec0 (embeddedTbl (Nullable Identity)))
+         (Rec0 (embeddedTbl (Nullable (Const cs)))) where
+  gDefaultBackendFieldSchemas pBe _ _ =
+    K1 $ to $ gDefaultBackendFieldSchemas pBe
+      (Proxy @(Rep (embeddedTbl (Nullable Identity)))) True
+

--- a/beam-migrate/beam-migrate.cabal
+++ b/beam-migrate/beam-migrate.cabal
@@ -45,6 +45,8 @@ library
 
                        Database.Beam.Migrate.Simple
 
+                       Database.Beam.Migrate.TempTable
+
                        Database.Beam.Haskell.Syntax
 
   other-modules:       Database.Beam.Migrate.Generics.Types

--- a/beam-postgres/ChangeLog.md
+++ b/beam-postgres/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Added features
 
+* Support for temporary tables.
+
 * `getDbConstraintsForSchemas` now discovers foreign key constraints
   via `pg_constraint`, including `ON DELETE` / `ON UPDATE` actions.
 

--- a/beam-postgres/Database/Beam/Postgres.hs
+++ b/beam-postgres/Database/Beam/Postgres.hs
@@ -43,6 +43,7 @@ module Database.Beam.Postgres
   , smallserial, serial, bigserial
 
   , module Database.Beam.Postgres.PgSpecific
+  , module Database.Beam.Postgres.TempTable
 
     -- ** Postgres extension support
   , PgExtensionEntity, IsPgExtension(..)
@@ -83,5 +84,6 @@ import Database.Beam.Postgres.Extensions ( PgExtensionEntity, IsPgExtension(..)
                                          , pgCreateExtension, pgDropExtension
                                          , getPgExtension )
 import Database.Beam.Postgres.Debug
+import Database.Beam.Postgres.TempTable
 
 import qualified Database.PostgreSQL.Simple as Pg

--- a/beam-postgres/Database/Beam/Postgres/TempTable.hs
+++ b/beam-postgres/Database/Beam/Postgres/TempTable.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE ConstraintKinds #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Database.Beam.Postgres.TempTable
+  ( -- * Temporary tables
+
+    -- ** @CREATE TEMPORARY TABLE@
+    runCreateTempTable
+
+    -- ** Options
+  , TempTableCreateMode(..)
+  , TempTableOptions(..)
+  , defaultTempTableOptions
+
+    -- ** Schema constraint
+  , HasDefaultPostgresTempTableSchema
+
+  ) where
+
+import           Database.Beam.Migrate.TempTable
+  ( BeamHasTempTables(..)
+  , HasDefaultTempTableSchema
+  , TempTableCreateMode(..)
+  , TempTableOptions(..)
+  , defaultTempTableOptions
+  , runCreateTempTable
+  )
+import           Database.Beam.Postgres.Types (Postgres)
+import           Database.Beam.Postgres.Syntax
+  ( PgCommandSyntax(..), PgCommandType(..)
+  , fromPgColumnSchema
+  , emit, pgQuotedIdentifier, pgSepBy, pgParens
+  )
+
+--------------------------------------------------------------------------------
+
+-- | Tables for which @CREATE TEMPORARY TABLE@ statements can be emitted
+-- automatically.
+type HasDefaultPostgresTempTableSchema tbl = HasDefaultTempTableSchema Postgres tbl
+
+instance BeamHasTempTables Postgres where
+  createTempTableCmd nm colDefs pkCols ifNotExists =
+    PgCommandSyntax PgCommandTypeDdl $
+      emit "CREATE TEMPORARY TABLE "
+        <> (if ifNotExists then emit "IF NOT EXISTS " else mempty)
+        <> pgQuotedIdentifier nm
+        <> pgParens (pgSepBy (emit ", ") (colDefPieces ++ pkPiece))
+    where
+      colDefPieces =
+        map (\(n, s) -> pgQuotedIdentifier n <> emit " " <> fromPgColumnSchema s)
+            colDefs
+
+      pkPiece
+        | null pkCols = []
+        | otherwise =
+            [ emit "PRIMARY KEY "
+                <> pgParens (pgSepBy (emit ", ") (map pgQuotedIdentifier pkCols)) ]
+
+  dropTempTableIfExistsCmd nm =
+    PgCommandSyntax PgCommandTypeDdl $
+      emit "DROP TABLE IF EXISTS " <> pgQuotedIdentifier nm

--- a/beam-postgres/beam-postgres.cabal
+++ b/beam-postgres/beam-postgres.cabal
@@ -25,6 +25,8 @@ library
                       Database.Beam.Postgres.PgCrypto
                       Database.Beam.Postgres.Extensions.UuidOssp
 
+                      Database.Beam.Postgres.TempTable
+
   other-modules:      Database.Beam.Postgres.Connection
                       Database.Beam.Postgres.Debug
                       Database.Beam.Postgres.Extensions
@@ -81,7 +83,8 @@ test-suite beam-postgres-tests
                  Database.Beam.Postgres.Test.Marshal,
                  Database.Beam.Postgres.Test.Select,
                  Database.Beam.Postgres.Test.DataTypes,
-                 Database.Beam.Postgres.Test.Migrate
+                 Database.Beam.Postgres.Test.Migrate,
+                 Database.Beam.Postgres.Test.TempTable
   build-depends:
     aeson,
     base,

--- a/beam-postgres/test/Database/Beam/Postgres/Test/TempTable.hs
+++ b/beam-postgres/test/Database/Beam/Postgres/Test/TempTable.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+module Database.Beam.Postgres.Test.TempTable (tests) where
+
+import Data.ByteString (ByteString)
+import Data.Int (Int32)
+import Data.Kind (Type)
+import GHC.Exts (Any)
+
+import Database.Beam
+import Database.Beam.Postgres
+import Database.PostgreSQL.Simple (execute_)
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Database.Beam.Postgres.Test
+
+tests :: IO ByteString -> TestTree
+tests getConn = testGroup "Temporary table tests"
+  [ testStageFilteredRows getConn
+  , testDropAndCreate      getConn
+  ]
+
+-- | A permanent table of items.
+data ItemT f = Item
+  { itemId    :: C f Int32
+  , itemValue :: C f Int32
+  } deriving (Generic, Beamable)
+
+deriving instance Show (ItemT Identity)
+deriving instance Eq   (ItemT Identity)
+
+instance Table ItemT where
+  data PrimaryKey ItemT f = ItemKey (C f Int32)
+    deriving (Generic, Beamable)
+  primaryKey = ItemKey . itemId
+
+data ItemDb entity = ItemDb
+  { dbItems :: entity (TableEntity ItemT)
+  } deriving (Generic, Database Postgres)
+
+itemDb :: DatabaseSettings be ItemDb
+itemDb = defaultDbSettings
+
+-- | Stage a filtered subset of a permanent table in a temp table using
+-- INSERT INTO temp SELECT ... FROM permanent WHERE ..., then read it back.
+testStageFilteredRows :: IO ByteString -> TestTree
+testStageFilteredRows getConn = testCase "sanity test" $
+  withTestPostgres "temp_table_stage" getConn $ \conn -> do
+    execute_ conn "CREATE TABLE items (id INT PRIMARY KEY, value INT NOT NULL)"
+    result <- runBeamPostgres conn $ do
+      runInsert $ insert (dbItems itemDb) $ insertValues
+        [ Item 1 5, Item 2 10, Item 3 15, Item 4 20, Item 5 25 ]
+      scratch <- runCreateTempTable @_ @Any @ItemT
+                   defaultTempTableOptions "high_value_items"
+      runInsert $ insert scratch $ insertFrom $
+        filter_ (\r -> itemValue r >. val_ 15) $
+        all_ (dbItems itemDb)
+      runSelectReturningList $ select $
+        orderBy_ (asc_ . itemId) $ all_ scratch
+    assertEqual "high-value items staged" [Item 4 20, Item 5 25] result
+
+testDropAndCreate :: IO ByteString -> TestTree
+testDropAndCreate getConn = testCase "drop-and-create" $
+  withTestPostgres "temp_table_drop_and_create" getConn $ \conn -> do
+    execute_ conn "CREATE TABLE items (id INT PRIMARY KEY, value INT NOT NULL)"
+    result <- runBeamPostgres conn $ do
+      runInsert $ insert (dbItems itemDb) $ insertValues
+        [ Item 1 5, Item 2 10, Item 3 15, Item 4 20, Item 5 25 ]
+      -- First pass: stage low-value items.
+      scratch <- runCreateTempTable @_ @Any @ItemT
+                   defaultTempTableOptions "scratch"
+      runInsert $ insert scratch $ insertFrom $
+        filter_ (\r -> itemValue r <=. val_ 15) $
+        all_ (dbItems itemDb)
+      -- Second pass: drop and recreate, then stage high-value items only.
+      scratch' <- runCreateTempTable @_ @Any @ItemT
+                    (defaultTempTableOptions { tempTableCreateMode = DropAndCreate })
+                    "scratch"
+      runInsert $ insert scratch' $ insertFrom $
+        filter_ (\r -> itemValue r >. val_ 15) $
+        all_ (dbItems itemDb)
+      runSelectReturningList $ select $
+        orderBy_ (asc_ . itemId) $ all_ scratch'
+    assertEqual "only high-value items after reset" [Item 4 20, Item 5 25] result

--- a/beam-postgres/test/Main.hs
+++ b/beam-postgres/test/Main.hs
@@ -11,6 +11,7 @@ import qualified Database.Beam.Postgres.Test.Select as Select
 import qualified Database.Beam.Postgres.Test.Marshal as Marshal
 import qualified Database.Beam.Postgres.Test.DataTypes as DataType
 import qualified Database.Beam.Postgres.Test.Migrate as Migrate
+import qualified Database.Beam.Postgres.Test.TempTable as TempTable
 import Database.PostgreSQL.Simple ( ConnectInfo(..), defaultConnectInfo )
 import qualified Database.PostgreSQL.Simple as Postgres
 
@@ -23,6 +24,7 @@ main = defaultMain
           , Select.tests getConnStr
           , DataType.tests getConnStr
           , Migrate.tests getConnStr
+          , TempTable.tests getConnStr
           ]
 
 

--- a/beam-sqlite/ChangeLog.md
+++ b/beam-sqlite/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Added features
 
+* Support for temporary tables.
+
 * `getDbConstraints` now discovers foreign key constraints via `PRAGMA foreign_key_list`, including `ON DELETE` / `ON UPDATE` actions.
 
 ## Bug fixes

--- a/beam-sqlite/Database/Beam/Sqlite.hs
+++ b/beam-sqlite/Database/Beam/Sqlite.hs
@@ -1,6 +1,7 @@
 module Database.Beam.Sqlite
   ( module Database.Beam.Sqlite.Connection
   , module Database.Beam.Sqlite.Migrate
+  , module Database.Beam.Sqlite.TempTable
 
     -- * SQLite syntaxes
   , SqliteCommandSyntax(..), SqliteSyntax
@@ -19,3 +20,4 @@ import Database.Beam.Sqlite.Syntax
 import Database.Beam.Sqlite.SqliteSpecific
 import Database.Beam.Sqlite.Connection
 import Database.Beam.Sqlite.Migrate (sqliteText, sqliteBlob, sqliteBigInt)
+import Database.Beam.Sqlite.TempTable

--- a/beam-sqlite/Database/Beam/Sqlite/TempTable.hs
+++ b/beam-sqlite/Database/Beam/Sqlite/TempTable.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE TypeApplications #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Database.Beam.Sqlite.TempTable
+  ( -- * Temporary tables
+
+    -- ** @CREATE TEMPORARY TABLE@
+    runCreateTempTable
+
+    -- ** Options
+  , TempTableCreateMode(..)
+  , TempTableOptions(..)
+  , defaultTempTableOptions
+
+    -- ** Schema constraint
+  , HasDefaultSqliteTempTableSchema
+
+  ) where
+
+import           Database.Beam.Migrate.TempTable
+  ( BeamHasTempTables(..)
+  , HasDefaultTempTableSchema
+  , TempTableCreateMode(..)
+  , TempTableOptions(..)
+  , defaultTempTableOptions
+  , runCreateTempTable
+  )
+import           Database.Beam.Sqlite.Connection (Sqlite)
+import           Database.Beam.Sqlite.Syntax
+  ( SqliteCommandSyntax(..)
+  , fromSqliteColumnSchema, sqliteIsSerialColumn
+  , emit, quotedIdentifier, parens, commas
+  )
+
+--------------------------------------------------------------------------------
+
+-- | Tables for which @CREATE TEMPORARY TABLE@ statements can be emitted
+-- automatically.
+type HasDefaultSqliteTempTableSchema tbl = HasDefaultTempTableSchema Sqlite tbl
+
+instance BeamHasTempTables Sqlite where
+  createTempTableCmd nm colDefs pkCols ifNotExists =
+    SqliteCommandSyntax $
+      emit "CREATE TEMPORARY TABLE "
+        <> (if ifNotExists then emit "IF NOT EXISTS " else mempty)
+        <> quotedIdentifier nm
+        <> parens (commas (colDefPieces ++ pkPiece))
+    where
+      colDefPieces =
+        map (\(n, s) -> quotedIdentifier n <> emit " " <> fromSqliteColumnSchema s)
+            colDefs
+
+      -- SQLite's INTEGER PRIMARY KEY AUTOINCREMENT already encodes the
+      -- primary key constraint, so a separate PRIMARY KEY constraint would
+      -- constitute a syntax error.
+      hasSerial = any (sqliteIsSerialColumn . snd) colDefs
+      pkPiece
+        | hasSerial || null pkCols = []
+        | otherwise =
+            [ emit "PRIMARY KEY "
+                <> parens (commas (map quotedIdentifier pkCols)) ]
+
+  dropTempTableIfExistsCmd nm =
+    SqliteCommandSyntax $
+      emit "DROP TABLE IF EXISTS " <> quotedIdentifier nm

--- a/beam-sqlite/beam-sqlite.cabal
+++ b/beam-sqlite/beam-sqlite.cabal
@@ -22,6 +22,7 @@ library
                       Database.Beam.Sqlite.Syntax
                       Database.Beam.Sqlite.Connection
                       Database.Beam.Sqlite.Migrate
+                      Database.Beam.Sqlite.TempTable
   other-modules:      Database.Beam.Sqlite.SqliteSpecific
   build-depends:      base          >=4.11 && <5,
 
@@ -79,6 +80,7 @@ test-suite beam-sqlite-tests
     Database.Beam.Sqlite.Test.Migrate
     Database.Beam.Sqlite.Test.Returning
     Database.Beam.Sqlite.Test.Select
+    Database.Beam.Sqlite.Test.TempTable
   default-language: Haskell2010
   default-extensions:
     DeriveAnyClass,

--- a/beam-sqlite/test/Database/Beam/Sqlite/Test/TempTable.hs
+++ b/beam-sqlite/test/Database/Beam/Sqlite/Test/TempTable.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Database.Beam.Sqlite.Test.TempTable (tests) where
+
+import Data.Int (Int32)
+import Data.Kind (Type)
+import GHC.Exts (Any)
+
+import Database.Beam
+import Database.Beam.Sqlite
+import Database.SQLite.Simple (execute_)
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Database.Beam.Sqlite.Test
+
+tests :: TestTree
+tests = testGroup "Temporary table tests"
+  [ testStageFilteredRows
+  , testDropAndCreate
+  ]
+
+-- | A permanent table of items.
+data ItemT f = Item
+  { itemId    :: C f Int32
+  , itemValue :: C f Int32
+  } deriving (Generic, Beamable)
+
+deriving instance Show (ItemT Identity)
+deriving instance Eq   (ItemT Identity)
+
+instance Table ItemT where
+  data PrimaryKey ItemT f = ItemKey (C f Int32)
+    deriving (Generic, Beamable)
+  primaryKey = ItemKey . itemId
+
+data ItemDb entity = ItemDb
+  { dbItems :: entity (TableEntity ItemT)
+  } deriving (Generic, Database Sqlite)
+
+itemDb :: DatabaseSettings be ItemDb
+itemDb = defaultDbSettings
+
+testStageFilteredRows :: TestTree
+testStageFilteredRows = testCase "sanity test" $
+  withTestDb $ \conn -> do
+    execute_ conn "CREATE TABLE items (id INT PRIMARY KEY, value INT NOT NULL)"
+    result <- runBeamSqlite conn $ do
+      runInsert $ insert (dbItems itemDb) $ insertValues
+        [ Item 1 5, Item 2 10, Item 3 15, Item 4 20, Item 5 25 ]
+      scratch <- runCreateTempTable @_ @Any @ItemT
+                   defaultTempTableOptions "high_value_items"
+      runInsert $ insert scratch $ insertFrom $
+        filter_ (\r -> itemValue r >. val_ 15) $
+        all_ (dbItems itemDb)
+      runSelectReturningList $ select $
+        orderBy_ (asc_ . itemId) $ all_ scratch
+    assertEqual "high-value items staged" [Item 4 20, Item 5 25] result
+
+-- | 'DropAndCreate' resets the temp table so a second pass populates a
+-- clean table, with no leftovers from the first pass.
+testDropAndCreate :: TestTree
+testDropAndCreate = testCase "drop-and-create" $
+  withTestDb $ \conn -> do
+    execute_ conn "CREATE TABLE items (id INT PRIMARY KEY, value INT NOT NULL)"
+    result <- runBeamSqlite conn $ do
+      runInsert $ insert (dbItems itemDb) $ insertValues
+        [ Item 1 5, Item 2 10, Item 3 15, Item 4 20, Item 5 25 ]
+      -- First pass: stage low-value items.
+      scratch <- runCreateTempTable @_ @Any @ItemT
+                   defaultTempTableOptions "scratch"
+      runInsert $ insert scratch $ insertFrom $
+        filter_ (\r -> itemValue r <=. val_ 15) $
+        all_ (dbItems itemDb)
+      -- Second pass: drop and recreate, then stage high-value items only.
+      scratch' <- runCreateTempTable @_ @Any @ItemT
+                    (defaultTempTableOptions { tempTableCreateMode = DropAndCreate })
+                    "scratch"
+      runInsert $ insert scratch' $ insertFrom $
+        filter_ (\r -> itemValue r >. val_ 15) $
+        all_ (dbItems itemDb)
+      runSelectReturningList $ select $
+        orderBy_ (asc_ . itemId) $ all_ scratch'
+    assertEqual "only high-value items after reset" [Item 4 20, Item 5 25] result

--- a/beam-sqlite/test/Main.hs
+++ b/beam-sqlite/test/Main.hs
@@ -7,6 +7,7 @@ import qualified Database.Beam.Sqlite.Test.Insert as Insert
 import qualified Database.Beam.Sqlite.Test.InsertOnConflictReturning as InsertOnConflictReturning
 import qualified Database.Beam.Sqlite.Test.Select as Select
 import qualified Database.Beam.Sqlite.Test.Returning as Returning
+import qualified Database.Beam.Sqlite.Test.TempTable as TempTable
 
 main :: IO ()
 main = defaultMain $ testGroup "beam-sqlite tests"
@@ -15,4 +16,5 @@ main = defaultMain $ testGroup "beam-sqlite tests"
       , Insert.tests
       , InsertOnConflictReturning.tests
       , Returning.tests
+      , TempTable.tests
       ]


### PR DESCRIPTION
This PR adds support for temporary tables to the SQLite and Postgres backends.

The main logic had to live in `beam-migrate` (not `beam-core`) as that's where the relevant DDL syntax lives (I found this a bit counter-intuitive).

Temporary tables can now be created with `runCreateTempTable`:

  - Creation takes a `TempTableOptions` argument which dictates whether to create the temporary table fresh; see `TempTableCreateMode`.
  - `runCreateTempTable` returns a normal table entity that can be used with other queries like any other table.