### PR TITLE
MonadBeam*Returning projection support

### DIFF
--- a/beam-core/Database/Beam/Backend/SQL/BeamExtensions.hs
+++ b/beam-core/Database/Beam/Backend/SQL/BeamExtensions.hs
@@ -41,108 +41,123 @@ import           Data.Semigroup
 
 --import GHC.Generics
 
--- | 'MonadBeam's that support returning the newly created rows of an @INSERT@ statement.
+-- | 'MonadBeam's that support returning data from the newly created rows of an @INSERT@ statement.
 --   Useful for discovering the real value of a defaulted value.
+--
+--   The projection function determines which columns are returned. Pass 'id' to
+--   return the full row ('table Identity'), or supply a custom projection to
+--   return a subset of columns.
 class MonadBeam be m =>
   MonadBeamInsertReturning be m | m -> be where
   runInsertReturningList
     :: ( Beamable table
-       , Projectible be (table (QExpr be ()))
-       , FromBackendRow be (table Identity) )
+       , Projectible be a
+       , FromBackendRow be (QExprToIdentity a) )
     => SqlInsert be table
-    -> m [table Identity]
+    -> (table (QExpr be ()) -> a)
+    -> m [QExprToIdentity a]
 
 instance MonadBeamInsertReturning be m => MonadBeamInsertReturning be (ExceptT e m) where
-    runInsertReturningList = lift . runInsertReturningList
+    runInsertReturningList sql proj = lift $ runInsertReturningList sql proj
 instance MonadBeamInsertReturning be m => MonadBeamInsertReturning be (ContT r m) where
-    runInsertReturningList = lift . runInsertReturningList
+    runInsertReturningList sql proj = lift $ runInsertReturningList sql proj
 instance MonadBeamInsertReturning be m => MonadBeamInsertReturning be (ReaderT r m) where
-    runInsertReturningList = lift . runInsertReturningList
+    runInsertReturningList sql proj = lift $ runInsertReturningList sql proj
 instance MonadBeamInsertReturning be m => MonadBeamInsertReturning be (Lazy.StateT r m) where
-    runInsertReturningList = lift . runInsertReturningList
+    runInsertReturningList sql proj = lift $ runInsertReturningList sql proj
 instance MonadBeamInsertReturning be m => MonadBeamInsertReturning be (Strict.StateT r m) where
-    runInsertReturningList = lift . runInsertReturningList
+    runInsertReturningList sql proj = lift $ runInsertReturningList sql proj
 instance (MonadBeamInsertReturning be m, Monoid r)
     => MonadBeamInsertReturning be (Lazy.WriterT r m) where
-    runInsertReturningList = lift . runInsertReturningList
+    runInsertReturningList sql proj = lift $ runInsertReturningList sql proj
 instance (MonadBeamInsertReturning be m, Monoid r)
     => MonadBeamInsertReturning be (Strict.WriterT r m) where
-    runInsertReturningList = lift . runInsertReturningList
+    runInsertReturningList sql proj = lift $ runInsertReturningList sql proj
 instance (MonadBeamInsertReturning be m, Monoid w)
     => MonadBeamInsertReturning be (Lazy.RWST r w s m) where
-    runInsertReturningList = lift . runInsertReturningList
+    runInsertReturningList sql proj = lift $ runInsertReturningList sql proj
 instance (MonadBeamInsertReturning be m, Monoid w)
     => MonadBeamInsertReturning be (Strict.RWST r w s m) where
-    runInsertReturningList = lift . runInsertReturningList
+    runInsertReturningList sql proj = lift $ runInsertReturningList sql proj
 
--- | 'MonadBeam's that support returning the updated rows of an @UPDATE@ statement.
+-- | 'MonadBeam's that support returning data from the updated rows of an @UPDATE@ statement.
 --   Useful for discovering the new values of the updated rows.
+--
+--   The projection function determines which columns are returned. Pass 'id' to
+--   return the full row ('table Identity'), or supply a custom projection to
+--   return a subset of columns.
 class MonadBeam be m =>
   MonadBeamUpdateReturning be m | m -> be where
   runUpdateReturningList
     :: ( Beamable table
-       , Projectible be (table (QExpr be ()))
-       , FromBackendRow be (table Identity) )
+       , Projectible be a
+       , FromBackendRow be (QExprToIdentity a) )
     => SqlUpdate be table
-    -> m [table Identity]
+    -> (table (QExpr be ()) -> a)
+    -> m [QExprToIdentity a]
 
 instance MonadBeamUpdateReturning be m => MonadBeamUpdateReturning be (ExceptT e m) where
-    runUpdateReturningList = lift . runUpdateReturningList
+    runUpdateReturningList sql proj = lift $ runUpdateReturningList sql proj
 instance MonadBeamUpdateReturning be m => MonadBeamUpdateReturning be (ContT r m) where
-    runUpdateReturningList = lift . runUpdateReturningList
+    runUpdateReturningList sql proj = lift $ runUpdateReturningList sql proj
 instance MonadBeamUpdateReturning be m => MonadBeamUpdateReturning be (ReaderT r m) where
-    runUpdateReturningList = lift . runUpdateReturningList
+    runUpdateReturningList sql proj = lift $ runUpdateReturningList sql proj
 instance MonadBeamUpdateReturning be m => MonadBeamUpdateReturning be (Lazy.StateT r m) where
-    runUpdateReturningList = lift . runUpdateReturningList
+    runUpdateReturningList sql proj = lift $ runUpdateReturningList sql proj
 instance MonadBeamUpdateReturning be m => MonadBeamUpdateReturning be (Strict.StateT r m) where
-    runUpdateReturningList = lift . runUpdateReturningList
+    runUpdateReturningList sql proj = lift $ runUpdateReturningList sql proj
 instance (MonadBeamUpdateReturning be m, Monoid r)
     => MonadBeamUpdateReturning be (Lazy.WriterT r m) where
-    runUpdateReturningList = lift . runUpdateReturningList
+    runUpdateReturningList sql proj = lift $ runUpdateReturningList sql proj
 instance (MonadBeamUpdateReturning be m, Monoid r)
     => MonadBeamUpdateReturning be (Strict.WriterT r m) where
-    runUpdateReturningList = lift . runUpdateReturningList
+    runUpdateReturningList sql proj = lift $ runUpdateReturningList sql proj
 instance (MonadBeamUpdateReturning be m, Monoid w)
     => MonadBeamUpdateReturning be (Lazy.RWST r w s m) where
-    runUpdateReturningList = lift . runUpdateReturningList
+    runUpdateReturningList sql proj = lift $ runUpdateReturningList sql proj
 instance (MonadBeamUpdateReturning be m, Monoid w)
     => MonadBeamUpdateReturning be (Strict.RWST r w s m) where
-    runUpdateReturningList = lift . runUpdateReturningList
+    runUpdateReturningList sql proj = lift $ runUpdateReturningList sql proj
 
--- | 'MonadBeam's that suppert returning rows that will be deleted by the given
--- @DELETE@ statement. Useful for deallocating resources based on the value of
--- deleted rows.
+-- | 'MonadBeam's that support returning data from rows that will be deleted by
+-- the given @DELETE@ statement. Useful for deallocating resources based on the
+-- value of deleted rows.
+--
+--   The projection function determines which columns are returned. Pass 'id' to
+--   return the full row ('table Identity'), or supply a custom projection to
+--   return a subset of columns.
 class MonadBeam be m =>
   MonadBeamDeleteReturning be m | m -> be where
   runDeleteReturningList
     :: ( Beamable table
-       , Projectible be (table (QExpr be ()))
-       , FromBackendRow be (table Identity) )
+       , Projectible be a
+       , FromBackendRow be (QExprToIdentity a) )
     => SqlDelete be table
-    -> m [table Identity]
+    -> (table (QExpr be ()) -> a)
+    -> m [QExprToIdentity a]
 
 instance MonadBeamDeleteReturning be m => MonadBeamDeleteReturning be (ExceptT e m) where
-    runDeleteReturningList = lift . runDeleteReturningList
+    runDeleteReturningList sql proj = lift $ runDeleteReturningList sql proj
 instance MonadBeamDeleteReturning be m => MonadBeamDeleteReturning be (ContT r m) where
-    runDeleteReturningList = lift . runDeleteReturningList
+    runDeleteReturningList sql proj = lift $ runDeleteReturningList sql proj
 instance MonadBeamDeleteReturning be m => MonadBeamDeleteReturning be (ReaderT r m) where
-    runDeleteReturningList = lift . runDeleteReturningList
+    runDeleteReturningList sql proj = lift $ runDeleteReturningList sql proj
 instance MonadBeamDeleteReturning be m => MonadBeamDeleteReturning be (Lazy.StateT r m) where
-    runDeleteReturningList = lift . runDeleteReturningList
+    runDeleteReturningList sql proj = lift $ runDeleteReturningList sql proj
 instance MonadBeamDeleteReturning be m => MonadBeamDeleteReturning be (Strict.StateT r m) where
-    runDeleteReturningList = lift . runDeleteReturningList
+    runDeleteReturningList sql proj = lift $ runDeleteReturningList sql proj
 instance (MonadBeamDeleteReturning be m, Monoid r)
     => MonadBeamDeleteReturning be (Lazy.WriterT r m) where
-    runDeleteReturningList = lift . runDeleteReturningList
+    runDeleteReturningList sql proj = lift $ runDeleteReturningList sql proj
 instance (MonadBeamDeleteReturning be m, Monoid r)
     => MonadBeamDeleteReturning be (Strict.WriterT r m) where
-    runDeleteReturningList = lift . runDeleteReturningList
+    runDeleteReturningList sql proj = lift $ runDeleteReturningList sql proj
 instance (MonadBeamDeleteReturning be m, Monoid w)
     => MonadBeamDeleteReturning be (Lazy.RWST r w s m) where
-    runDeleteReturningList = lift . runDeleteReturningList
+    runDeleteReturningList sql proj = lift $ runDeleteReturningList sql proj
 instance (MonadBeamDeleteReturning be m, Monoid w)
     => MonadBeamDeleteReturning be (Strict.RWST r w s m) where
-    runDeleteReturningList = lift . runDeleteReturningList
+    runDeleteReturningList sql proj = lift $ runDeleteReturningList sql proj
 
 class BeamSqlBackend be => BeamHasInsertOnConflict be where
   -- | Specifies the kind of constraint that must be violated for the action to occur

--- a/beam-postgres/Database/Beam/Postgres/Connection.hs
+++ b/beam-postgres/Database/Beam/Postgres/Connection.hs
@@ -405,12 +405,11 @@ instance MonadBeam Postgres Pg where
           in collectM id
 
 instance MonadBeamInsertReturning Postgres Pg where
-    runInsertReturningList i = do
-        let insertReturningCmd' = i `returning`
-              changeBeamRep (\(Columnar' (QExpr s) :: Columnar' (QExpr Postgres PostgresInaccessible) ty) ->
-                Columnar' (QExpr s) :: Columnar' (QExpr Postgres ()) ty)
-
-        -- Make savepoint
+    runInsertReturningList i mkProjection = do
+        let pgProj tbl = mkProjection (changeBeamRep
+              (\(Columnar' (QExpr s) :: Columnar' (QExpr Postgres PostgresInaccessible) ty) ->
+                Columnar' (QExpr s) :: Columnar' (QExpr Postgres ()) ty) tbl)
+            insertReturningCmd' = i `returning` pgProj
         case insertReturningCmd' of
           PgInsertReturningEmpty ->
             pure []
@@ -418,11 +417,11 @@ instance MonadBeamInsertReturning Postgres Pg where
             runReturningList (PgCommandSyntax PgCommandTypeDataUpdateReturning insertReturningCmd)
 
 instance MonadBeamUpdateReturning Postgres Pg where
-    runUpdateReturningList u = do
-        let updateReturningCmd' = u `returning`
-              changeBeamRep (\(Columnar' (QExpr s) :: Columnar' (QExpr Postgres PostgresInaccessible) ty) ->
-                Columnar' (QExpr s) :: Columnar' (QExpr Postgres ()) ty)
-
+    runUpdateReturningList u mkProjection = do
+        let pgProj tbl = mkProjection (changeBeamRep
+              (\(Columnar' (QExpr s) :: Columnar' (QExpr Postgres PostgresInaccessible) ty) ->
+                Columnar' (QExpr s) :: Columnar' (QExpr Postgres ()) ty) tbl)
+            updateReturningCmd' = u `returning` pgProj
         case updateReturningCmd' of
           PgUpdateReturningEmpty ->
             pure []
@@ -430,9 +429,9 @@ instance MonadBeamUpdateReturning Postgres Pg where
             runReturningList (PgCommandSyntax PgCommandTypeDataUpdateReturning updateReturningCmd)
 
 instance MonadBeamDeleteReturning Postgres Pg where
-    runDeleteReturningList d = do
-        let PgDeleteReturning deleteReturningCmd = d `returning`
-              changeBeamRep (\(Columnar' (QExpr s) :: Columnar' (QExpr Postgres PostgresInaccessible) ty) ->
-                Columnar' (QExpr s) :: Columnar' (QExpr Postgres ()) ty)
-
+    runDeleteReturningList d mkProjection = do
+        let pgProj tbl = mkProjection (changeBeamRep
+              (\(Columnar' (QExpr s) :: Columnar' (QExpr Postgres PostgresInaccessible) ty) ->
+                Columnar' (QExpr s) :: Columnar' (QExpr Postgres ()) ty) tbl)
+            PgDeleteReturning deleteReturningCmd = d `returning` pgProj
         runReturningList (PgCommandSyntax PgCommandTypeDataUpdateReturning deleteReturningCmd)

--- a/beam-postgres/test/Database/Beam/Postgres/Test/DataTypes.hs
+++ b/beam-postgres/test/Database/Beam/Postgres/Test/DataTypes.hs
@@ -121,7 +121,7 @@ errorOnSchemaMismatch pgConn =
             (RealDb <$> createTable "tbl1" (Tbl (field "key" int notNull)
                                                 (field "value" (varchar Nothing) notNull)))
 
-          runInsertReturningList $ insert (_realTbl realDb) $ insertValues [ Tbl 1 "hello", Tbl 2 "world", Tbl 3 "foo" ]
+          runInsertReturningList (insert (_realTbl realDb) $ insertValues [ Tbl 1 "hello", Tbl 2 "world", Tbl 3 "foo" ]) id
 
       vs @?= [ Tbl 1 "hello", Tbl 2 "world", Tbl 3 "foo" ]
 
@@ -132,7 +132,7 @@ errorOnSchemaMismatch pgConn =
 
       didFail <- handle (\(_ :: SomeException) -> pure True) $
         runBeamPostgres conn $ do
-          _ <- runInsertReturningList $ insert (_wrongTbl wrongDb) $ insertValues [ WrongTbl 4 23, WrongTbl 5 24, WrongTbl 6 24 ]
+          _ <- runInsertReturningList (insert (_wrongTbl wrongDb) $ insertValues [ WrongTbl 4 23, WrongTbl 5 24, WrongTbl 6 24 ]) id
           pure False
 
       assertBool "runInsertReturningList succeeded" didFail

--- a/beam-postgres/test/Database/Beam/Postgres/Test/Marshal.hs
+++ b/beam-postgres/test/Database/Beam/Postgres/Test/Marshal.hs
@@ -173,7 +173,7 @@ marshalTest' cmp gen postgresConn =
 
       [MarshalTable rowId v] <-
         liftIO . runBeamPostgres conn $
-        runInsertReturningList $ insert (_marshalTbl marshalDb) $ insertExpressions [ MarshalTable default_ (val_ a) ]
+        runInsertReturningList (insert (_marshalTbl marshalDb) $ insertExpressions [ MarshalTable default_ (val_ a) ]) id
       v `cmp` a
 
       Just (MarshalTable _ v') <-

--- a/beam-sqlite/Database/Beam/Sqlite/Connection.hs
+++ b/beam-sqlite/Database/Beam/Sqlite/Connection.hs
@@ -69,7 +69,7 @@ import           Database.SQLite.Simple.Ok (Ok(..))
 import           Database.SQLite.Simple.Types (Null)
 
 import           Control.Exception (SomeException(..))
-import           Control.Monad (forM_)
+import           Control.Monad (forM, forM_)
 import           Control.Monad.Base (MonadBase)
 import           Control.Monad.Fail (MonadFail(..))
 import           Control.Monad.Free.Church
@@ -386,20 +386,27 @@ unfoldM f = go []
     go acc = f >>= maybe (pure acc) (\x -> go (x : acc))
 
 instance Beam.MonadBeamInsertReturning Sqlite SqliteM where
-  runInsertReturningList SqlInsertNoRows = pure []
-  runInsertReturningList (SqlInsert _ insertCommand) = runReturningList $ SqliteCommandInsert insertCommand
+  runInsertReturningList SqlInsertNoRows _ = pure []
+  runInsertReturningList (SqlInsert tblSettings (SqliteInsertSyntax tbl fields values onConflict)) mkProjection =
+    fmap concat $ forM (sqliteGroupByDefaults fields values) $ \(fields', values') ->
+      runReturningList $ SqliteCommandSyntax $
+        formatSqliteInsertOnConflict tbl fields' values' onConflict
+        <> returningClauseWithProjection tblSettings mkProjection
 
 -- |
 -- @since 0.6.0.0
 instance Beam.MonadBeamUpdateReturning Sqlite SqliteM where
-  runUpdateReturningList :: forall table. (
-    Beamable table, Projectible Sqlite (table (QExpr Sqlite ())), FromBackendRow Sqlite (table Identity)
-    ) => SqlUpdate Sqlite table -> SqliteM [table Identity]
-  runUpdateReturningList SqlIdentityUpdate = pure []
-  runUpdateReturningList (SqlUpdate tblSettings sqliteUpdate) =
+  runUpdateReturningList SqlIdentityUpdate _ = pure []
+  runUpdateReturningList (SqlUpdate tblSettings sqliteUpdate) mkProjection =
     runReturningList $ SqliteCommandSyntax $
       fromSqliteUpdate sqliteUpdate
-        <> returningClauseWithProjection tblSettings (id :: table (QExpr Sqlite ()) -> table (QExpr Sqlite ()))
+        <> returningClauseWithProjection tblSettings mkProjection
+
+instance Beam.MonadBeamDeleteReturning Sqlite SqliteM where
+  runDeleteReturningList (SqlDelete tblSettings sqliteDelete) mkProjection =
+    runReturningList $ SqliteCommandSyntax $
+      fromSqliteDelete sqliteDelete
+        <> returningClauseWithProjection tblSettings mkProjection
 
 newtype SqliteInsertReturning a = SqliteInsertReturning [SqliteSyntax]
 newtype SqliteDeleteReturning a = SqliteDeleteReturning SqliteSyntax

--- a/beam-sqlite/Database/Beam/Sqlite/Connection.hs
+++ b/beam-sqlite/Database/Beam/Sqlite/Connection.hs
@@ -16,11 +16,11 @@ module Database.Beam.Sqlite.Connection
 
     -- ** @INSERT ... RETURNING@
   , SqliteInsertReturning
-  , insertReturning, insertOnConflictReturning, runInsertReturningList
+  , insertReturning, insertOnConflictReturning, runSqliteInsertReturningList
 
     -- ** @DELETE ... RETURNING@
   , SqliteDeleteReturning
-  , deleteReturning, runDeleteReturningList
+  , deleteReturning, runSqliteDeleteReturningList
 
     -- ** @UPDATE ... RETURNING@
   , SqliteUpdateReturning
@@ -452,14 +452,14 @@ sqliteGroupByDefaults flds orig@(SqliteInsertFromSql {}) =
   -- Preserve manually-written queries
   [(flds, orig)]
 
-runDeleteReturningList
+runSqliteDeleteReturningList
   :: ( MonadBeam be m
      , BeamSqlBackendSyntax be ~ SqliteCommandSyntax
      , FromBackendRow be a
      )
   => SqliteDeleteReturning a
   -> m [a]
-runDeleteReturningList (SqliteDeleteReturning syntax) =
+runSqliteDeleteReturningList (SqliteDeleteReturning syntax) =
   runReturningList $ SqliteCommandSyntax syntax
 
 -- | SQLite @DELETE ... RETURNING@ statement support. The last
@@ -556,14 +556,14 @@ insertOnConflictReturning
 
 -- | Runs a 'SqliteInsertReturning' statement and returns a result for each
 -- inserted row.
-runInsertReturningList
+runSqliteInsertReturningList
   :: ( MonadBeam be m
      , BeamSqlBackendSyntax be ~ SqliteCommandSyntax
      , FromBackendRow be a
      )
   => SqliteInsertReturning a
   -> m [a]
-runInsertReturningList (SqliteInsertReturning syntaxes) =
+runSqliteInsertReturningList (SqliteInsertReturning syntaxes) =
   concat <$>
     traverse (\syntax -> runReturningList $ SqliteCommandSyntax syntax) syntaxes
 

--- a/beam-sqlite/test/Database/Beam/Sqlite/Test/Insert.hs
+++ b/beam-sqlite/test/Database/Beam/Sqlite/Test/Insert.hs
@@ -56,11 +56,12 @@ testInsertReturningColumnOrder = testCase "runInsertReturningList with mismatchi
   withTestDb $ \conn -> do
     execute_ conn "CREATE TABLE test_table ( date_joined TIMESTAMP NOT NULL, date_logged_in TIMESTAMP WITH TIME ZONE NOT NULL, first_name TEXT NOT NULL, id INT PRIMARY KEY, age INT NOT NULL, last_name TEXT NOT NULL )"
     inserted <-
-      runBeamSqlite conn $ runInsertReturningList $
-      insert (dbTestTable testDatabase) $
+      runBeamSqlite conn $ runInsertReturningList
+      (insert (dbTestTable testDatabase) $
       insertExpressions [ TestTable 0 (concat_ [ "j", "im" ]) "smith" 19 currentTimestamp_ (val_ zeroUtcTime)
                         , TestTable 1 "sally" "apple" ((val_ 56 + val_ 109) `div_` 5) currentTimestamp_ (val_ oneUtcTime)
-                        , TestTable 4 "blah" "blah" (-1) currentTimestamp_ (val_ now) ]
+                        , TestTable 4 "blah" "blah" (-1) currentTimestamp_ (val_ now) ])
+      id
 
     let dateJoined : _ = ttDateJoined <$> inserted
 
@@ -95,11 +96,12 @@ testInsertOnlyDefaults :: TestTree
 testInsertOnlyDefaults = testCase "insert only default values" $
   withTestDb $ \conn -> do
     execute_ conn "CREATE TABLE with_defaults (id INTEGER PRIMARY KEY, value TEXT NOT NULL DEFAULT \"unknown\")"
-    inserted <- runBeamSqlite conn $ runInsertReturningList $
-      insert (tblWithDefaults withDefaultsDb) $ insertExpressions
+    inserted <- runBeamSqlite conn $ runInsertReturningList
+      (insert (tblWithDefaults withDefaultsDb) $ insertExpressions
         [ WithDefaults default_ default_
         , WithDefaults default_ $ val_ "other"
-        ]
+        ])
+      id
     assertEqual "inserted values"
       [ WithDefaults 1 "unknown"
       , WithDefaults 2 "other"
@@ -110,8 +112,8 @@ testUpsertOnlyDefaults :: TestTree
 testUpsertOnlyDefaults = testCase "upsert only default values" $
   withTestDb $ \conn -> do
     execute_ conn "CREATE TABLE with_defaults (id INTEGER PRIMARY KEY, value TEXT NOT NULL DEFAULT \"unknown\")"
-    inserted <- runBeamSqlite conn $ runInsertReturningList $
-      insertOnConflict (tblWithDefaults withDefaultsDb)
+    inserted <- runBeamSqlite conn $ runInsertReturningList
+      (insertOnConflict (tblWithDefaults withDefaultsDb)
         ( insertExpressions
             [ WithDefaults default_ default_
             , WithDefaults default_ $ val_ "other"
@@ -119,6 +121,8 @@ testUpsertOnlyDefaults = testCase "upsert only default values" $
         )
         anyConflict
         onConflictDoNothing
+      )
+      id
     assertEqual "inserted values"
       [ WithDefaults 1 "unknown"
       , WithDefaults 2 "other"
@@ -156,13 +160,14 @@ testInsertSomeDefaults = testCase "insert mix of default values" $ do
   withTestDb $ \conn -> do
     execute_ conn "CREATE TABLE mix_table ( id INTEGER PRIMARY KEY AUTOINCREMENT, field1 INT DEFAULT 11, field2 INT DEFAULT 22, field3 INT DEFAULT 33)"
     inserted <-
-      runBeamSqlite conn $ runInsertReturningList $
-      insert (dbMixTable mixDatabase) $
+      runBeamSqlite conn $ runInsertReturningList
+      (insert (dbMixTable mixDatabase) $
       insertExpressions [ MixTable default_ default_ 1001     10001
                         , MixTable 202      2        default_ default_
                         , MixTable 303      3        default_ default_
                         , MixTable default_ default_ 4004     40004
-                        ]
+                        ])
+      id
 
     let expected = [ MixTable 1   11 1001 10001
                    , MixTable 202 2  22   33

--- a/beam-sqlite/test/Database/Beam/Sqlite/Test/InsertOnConflictReturning.hs
+++ b/beam-sqlite/test/Database/Beam/Sqlite/Test/InsertOnConflictReturning.hs
@@ -112,8 +112,8 @@ testInsertOnConflictReturning = testCase "Check that conflicting values are retu
                         , User{userId = 2, userName = "different_user2"}
                         ]
 
-                runInsertReturningList $
-                    insertOnConflict
+                runInsertReturningList
+                    (insertOnConflict
                         (usersTable testDb)
                         (insertValues newUsers)
                         (conflictingFields userId)
@@ -126,7 +126,8 @@ testInsertOnConflictReturning = testCase "Check that conflicting values are retu
                                (User{userName = excl}) ->
                                     current_ fld /=. excl
                             )
-                        )
+                        ))
+                    userId
 
         -- Expecting that the conflicting user, User id 2, is also returned
-        userId <$> conflicts @?= [1, 2]
+        conflicts @?= [1, 2]

--- a/beam-sqlite/test/Database/Beam/Sqlite/Test/Returning.hs
+++ b/beam-sqlite/test/Database/Beam/Sqlite/Test/Returning.hs
@@ -15,20 +15,20 @@ import Test.Tasty.HUnit (testCase, (@?=))
 
 import Database.Beam
 import Database.Beam.Backend.SQL.BeamExtensions
-  (conflictingFields, onConflictUpdateSet, onConflictUpdateSetWhere, runUpdateReturningList)
+  ( conflictingFields, onConflictUpdateSet, onConflictUpdateSetWhere
+  , runInsertReturningList, runUpdateReturningList, runDeleteReturningList
+  )
 import Database.Beam.Migrate (defaultMigratableDbSettings)
 import Database.Beam.Migrate.Simple (CheckedDatabaseSettings, autoMigrate)
-import Database.Beam.Sqlite (Sqlite, runBeamSqlite, insertOnConflictReturning)
+import Database.Beam.Sqlite (
+  Sqlite, runBeamSqlite
+  , insertOnConflictReturning
+  , runSqliteInsertReturningList
+  , runSqliteUpdateReturningList
+  , runSqliteDeleteReturningList
+  )
+import qualified Database.Beam.Sqlite as Sqlite (deleteReturning, insertReturning, updateReturning)
 import Database.Beam.Sqlite.Migrate (migrationBackend)
-
-import Database.Beam.Sqlite
-    ( deleteReturning
-    , insertReturning
-    , runDeleteReturningList
-    , runInsertReturningList
-    , runSqliteUpdateReturningList
-    , updateReturning
-    )
 
 import Database.Beam.Sqlite.Test (withTestDb)
 
@@ -39,8 +39,11 @@ tests =
         "SQLite RETURNING statement tests"
         [ testInsertOnConflictReturning
         , testSqliteUpdateReturning
-        , testUpdateReturning
         , testDeleteReturning
+
+        , testClassInsertReturning
+        , testClassUpdateReturning
+        , testClassDeleteReturning
         ]
 
 -- | Database Schema Definition
@@ -104,7 +107,7 @@ testInsertOnConflictReturning = testCase "INSERT .. ON CONFLICT .. RETURNING" $
             ]
 
         -- Run 'INSERT .. ON CONFLICT (id) DO UPDATE SET .. WHERE .. RETURNING ..'
-        runInsertReturningList $
+        runSqliteInsertReturningList $
           insertOnConflictReturning
             (usersTable testDb)
             (insertValues newUsers)
@@ -144,40 +147,13 @@ testSqliteUpdateReturning = testCase "UPDATE .. RETURNING" $
 
         -- Update user 2 and return projected columns from the updated row
         runSqliteUpdateReturningList $
-          updateReturning
+          Sqlite.updateReturning
             (usersTable testDb)
             (\u -> userName u <-. val_ "updated_user2")
             (\u -> userId u ==. val_ 2)
             (\u -> (userId u, userName u, userInfo2 u))
 
     updatedUsers @?= [(2, "updated_user2", 22)]
-
--- | Test @UPDATE ... RETURNING@ using MonadBeamUpdateReturning's runUpdateReturningList
-testUpdateReturning :: TestTree
-testUpdateReturning = testCase "UPDATE .. RETURNING" $
-  withTestDb $ \conn -> do
-    updatedUsers <-
-      runBeamSqlite conn $ do
-        autoMigrate migrationBackend checkedDb
-
-        -- Seed data
-        runInsert $
-          insert (usersTable testDb) $
-            insertValues
-              [ User {userId = 1, userName = "user1", userInfo1 = "user1Info1", userInfo2 = 11 }
-              , User {userId = 2, userName = "user2", userInfo1 = "user2Info1", userInfo2 = 22 }
-              , User {userId = 3, userName = "user3", userInfo1 = "user3Info1", userInfo2 = 33 }
-              ]
-
-        -- Update user 2 and return projected columns from the updated row
-        runUpdateReturningList $
-          update
-            (usersTable testDb)
-            (\u -> userName u <-. val_ "updated_user2")
-            (\u -> userId u ==. val_ 2)
-
-
-    fmap (\u -> (userId u, userName u, userInfo2 u)) updatedUsers @?= [(2, "updated_user2", 22)]
 
 -- | Test @DELETE .. RETURNING@
 testDeleteReturning :: TestTree
@@ -197,10 +173,65 @@ testDeleteReturning = testCase "DELETE .. RETURNING" $
               ]
 
         -- Delete user 3 and return projected columns from the deleted row
-        runDeleteReturningList $
-          deleteReturning
+        runSqliteDeleteReturningList $
+          Sqlite.deleteReturning
             (usersTable testDb)
             (\u -> userId u ==. val_ 3)
             (\u -> (userName u, userInfo2 u))
 
     deletedUsers @?= [("user3", 33)]
+
+-- | Test class-level @INSERT .. RETURNING@ with custom projection
+testClassInsertReturning :: TestTree
+testClassInsertReturning = testCase "Class INSERT .. RETURNING" $
+  withTestDb $ \conn -> do
+    results <-
+      runBeamSqlite conn $ do
+        autoMigrate migrationBackend checkedDb
+        runInsertReturningList
+          (insert (usersTable testDb) $
+            insertValues
+              [ User {userId = 1, userName = "user1", userInfo1 = "info1", userInfo2 = 11 }
+              , User {userId = 2, userName = "user2", userInfo1 = "info2", userInfo2 = 22 }
+              ])
+          (\u -> (userId u, userName u))
+    results @?= [(1, "user1"), (2, "user2")]
+
+-- | Test class-level @UPDATE .. RETURNING@ with custom projection
+testClassUpdateReturning :: TestTree
+testClassUpdateReturning = testCase "Class UPDATE .. RETURNING" $
+  withTestDb $ \conn -> do
+    results <-
+      runBeamSqlite conn $ do
+        autoMigrate migrationBackend checkedDb
+        runInsert $
+          insert (usersTable testDb) $
+            insertValues
+              [ User {userId = 1, userName = "user1", userInfo1 = "info1", userInfo2 = 11 }
+              , User {userId = 2, userName = "user2", userInfo1 = "info2", userInfo2 = 22 }
+              ]
+        runUpdateReturningList
+          (update (usersTable testDb)
+            (\u -> userName u <-. val_ "updated")
+            (\u -> userId u ==. val_ 2))
+          (\u -> (userId u, userName u))
+    results @?= [(2, "updated")]
+
+-- | Test class-level @DELETE .. RETURNING@ with custom projection
+testClassDeleteReturning :: TestTree
+testClassDeleteReturning = testCase "Class DELETE .. RETURNING" $
+  withTestDb $ \conn -> do
+    results <-
+      runBeamSqlite conn $ do
+        autoMigrate migrationBackend checkedDb
+        runInsert $
+          insert (usersTable testDb) $
+            insertValues
+              [ User {userId = 1, userName = "user1", userInfo1 = "info1", userInfo2 = 11 }
+              , User {userId = 2, userName = "user2", userInfo1 = "info2", userInfo2 = 22 }
+              ]
+        runDeleteReturningList
+          (delete (usersTable testDb)
+            (\u -> userId u ==. val_ 2))
+          (\u -> (userName u, userInfo2 u))
+    results @?= [("user2", 22)]


### PR DESCRIPTION
This implements the idea from https://github.com/haskell-beam/beam/issues/775 and closes that issue.

I'm happy to re-target this against the `beam-0.11` branch if desired. It might need a rebase on the latest `master` though?

I realized that in #799, I probably should have done `MonadBeamInsertReturning` and `MonadBeamDeleteReturning` as well...