### PR TITLE
MonadBeam*Returning projection support (against beam-0.11)

### DIFF
--- a/beam-core/ChangeLog.md
+++ b/beam-core/ChangeLog.md
@@ -1,3 +1,10 @@
+
+# 0.11.0.0
+
+* Make the input of `values_` a non-empty list.
+* Add 'week' to date extraction.
+* Add *with projection methods to MonadBeamInsertReturning/MonadBeamUpdateReturning/MonadBeamDeleteReturning
+
 # 0.10.5.0
 
 ## Updated dependencies

--- a/beam-core/Database/Beam/Backend/SQL/BeamExtensions.hs
+++ b/beam-core/Database/Beam/Backend/SQL/BeamExtensions.hs
@@ -41,108 +41,144 @@ import           Data.Semigroup
 
 --import GHC.Generics
 
--- | 'MonadBeam's that support returning the newly created rows of an @INSERT@ statement.
+-- | 'MonadBeam's that support returning data from the newly created rows of an @INSERT@ statement.
 --   Useful for discovering the real value of a defaulted value.
+--
+--   The projection function determines which columns are returned. Pass 'id' to
+--   return the full row ('table Identity'), or supply a custom projection to
+--   return a subset of columns.
 class MonadBeam be m =>
   MonadBeamInsertReturning be m | m -> be where
+  runInsertReturningListWith
+    :: ( Beamable table
+       , Projectible be a
+       , FromBackendRow be (QExprToIdentity a) )
+    => SqlInsert be table
+    -> (table (QExpr be ()) -> a)
+    -> m [QExprToIdentity a]
   runInsertReturningList
     :: ( Beamable table
        , Projectible be (table (QExpr be ()))
        , FromBackendRow be (table Identity) )
     => SqlInsert be table
     -> m [table Identity]
+  runInsertReturningList sql = runInsertReturningListWith sql id
 
 instance MonadBeamInsertReturning be m => MonadBeamInsertReturning be (ExceptT e m) where
-    runInsertReturningList = lift . runInsertReturningList
+    runInsertReturningListWith sql proj = lift $ runInsertReturningListWith sql proj
 instance MonadBeamInsertReturning be m => MonadBeamInsertReturning be (ContT r m) where
-    runInsertReturningList = lift . runInsertReturningList
+    runInsertReturningListWith sql proj = lift $ runInsertReturningListWith sql proj
 instance MonadBeamInsertReturning be m => MonadBeamInsertReturning be (ReaderT r m) where
-    runInsertReturningList = lift . runInsertReturningList
+    runInsertReturningListWith sql proj = lift $ runInsertReturningListWith sql proj
 instance MonadBeamInsertReturning be m => MonadBeamInsertReturning be (Lazy.StateT r m) where
-    runInsertReturningList = lift . runInsertReturningList
+    runInsertReturningListWith sql proj = lift $ runInsertReturningListWith sql proj
 instance MonadBeamInsertReturning be m => MonadBeamInsertReturning be (Strict.StateT r m) where
-    runInsertReturningList = lift . runInsertReturningList
+    runInsertReturningListWith sql proj = lift $ runInsertReturningListWith sql proj
 instance (MonadBeamInsertReturning be m, Monoid r)
     => MonadBeamInsertReturning be (Lazy.WriterT r m) where
-    runInsertReturningList = lift . runInsertReturningList
+    runInsertReturningListWith sql proj = lift $ runInsertReturningListWith sql proj
 instance (MonadBeamInsertReturning be m, Monoid r)
     => MonadBeamInsertReturning be (Strict.WriterT r m) where
-    runInsertReturningList = lift . runInsertReturningList
+    runInsertReturningListWith sql proj = lift $ runInsertReturningListWith sql proj
 instance (MonadBeamInsertReturning be m, Monoid w)
     => MonadBeamInsertReturning be (Lazy.RWST r w s m) where
-    runInsertReturningList = lift . runInsertReturningList
+    runInsertReturningListWith sql proj = lift $ runInsertReturningListWith sql proj
 instance (MonadBeamInsertReturning be m, Monoid w)
     => MonadBeamInsertReturning be (Strict.RWST r w s m) where
-    runInsertReturningList = lift . runInsertReturningList
+    runInsertReturningListWith sql proj = lift $ runInsertReturningListWith sql proj
 
--- | 'MonadBeam's that support returning the updated rows of an @UPDATE@ statement.
+-- | 'MonadBeam's that support returning data from the updated rows of an @UPDATE@ statement.
 --   Useful for discovering the new values of the updated rows.
+--
+--   The projection function determines which columns are returned. Pass 'id' to
+--   return the full row ('table Identity'), or supply a custom projection to
+--   return a subset of columns.
 class MonadBeam be m =>
   MonadBeamUpdateReturning be m | m -> be where
+  runUpdateReturningListWith
+    :: ( Beamable table
+       , Projectible be a
+       , FromBackendRow be (QExprToIdentity a) )
+    => SqlUpdate be table
+    -> (table (QExpr be ()) -> a)
+    -> m [QExprToIdentity a]
   runUpdateReturningList
     :: ( Beamable table
        , Projectible be (table (QExpr be ()))
        , FromBackendRow be (table Identity) )
     => SqlUpdate be table
     -> m [table Identity]
+  runUpdateReturningList sql = runUpdateReturningListWith sql id
 
 instance MonadBeamUpdateReturning be m => MonadBeamUpdateReturning be (ExceptT e m) where
-    runUpdateReturningList = lift . runUpdateReturningList
+    runUpdateReturningListWith sql proj = lift $ runUpdateReturningListWith sql proj
 instance MonadBeamUpdateReturning be m => MonadBeamUpdateReturning be (ContT r m) where
-    runUpdateReturningList = lift . runUpdateReturningList
+    runUpdateReturningListWith sql proj = lift $ runUpdateReturningListWith sql proj
 instance MonadBeamUpdateReturning be m => MonadBeamUpdateReturning be (ReaderT r m) where
-    runUpdateReturningList = lift . runUpdateReturningList
+    runUpdateReturningListWith sql proj = lift $ runUpdateReturningListWith sql proj
 instance MonadBeamUpdateReturning be m => MonadBeamUpdateReturning be (Lazy.StateT r m) where
-    runUpdateReturningList = lift . runUpdateReturningList
+    runUpdateReturningListWith sql proj = lift $ runUpdateReturningListWith sql proj
 instance MonadBeamUpdateReturning be m => MonadBeamUpdateReturning be (Strict.StateT r m) where
-    runUpdateReturningList = lift . runUpdateReturningList
+    runUpdateReturningListWith sql proj = lift $ runUpdateReturningListWith sql proj
 instance (MonadBeamUpdateReturning be m, Monoid r)
     => MonadBeamUpdateReturning be (Lazy.WriterT r m) where
-    runUpdateReturningList = lift . runUpdateReturningList
+    runUpdateReturningListWith sql proj = lift $ runUpdateReturningListWith sql proj
 instance (MonadBeamUpdateReturning be m, Monoid r)
     => MonadBeamUpdateReturning be (Strict.WriterT r m) where
-    runUpdateReturningList = lift . runUpdateReturningList
+    runUpdateReturningListWith sql proj = lift $ runUpdateReturningListWith sql proj
 instance (MonadBeamUpdateReturning be m, Monoid w)
     => MonadBeamUpdateReturning be (Lazy.RWST r w s m) where
-    runUpdateReturningList = lift . runUpdateReturningList
+    runUpdateReturningListWith sql proj = lift $ runUpdateReturningListWith sql proj
 instance (MonadBeamUpdateReturning be m, Monoid w)
     => MonadBeamUpdateReturning be (Strict.RWST r w s m) where
-    runUpdateReturningList = lift . runUpdateReturningList
+    runUpdateReturningListWith sql proj = lift $ runUpdateReturningListWith sql proj
 
--- | 'MonadBeam's that suppert returning rows that will be deleted by the given
--- @DELETE@ statement. Useful for deallocating resources based on the value of
--- deleted rows.
+-- | 'MonadBeam's that support returning data from rows that will be deleted by
+-- the given @DELETE@ statement. Useful for deallocating resources based on the
+-- value of deleted rows.
+--
+--   The projection function determines which columns are returned. Pass 'id' to
+--   return the full row ('table Identity'), or supply a custom projection to
+--   return a subset of columns.
 class MonadBeam be m =>
   MonadBeamDeleteReturning be m | m -> be where
+  runDeleteReturningListWith
+    :: ( Beamable table
+       , Projectible be a
+       , FromBackendRow be (QExprToIdentity a) )
+    => SqlDelete be table
+    -> (table (QExpr be ()) -> a)
+    -> m [QExprToIdentity a]
   runDeleteReturningList
     :: ( Beamable table
        , Projectible be (table (QExpr be ()))
        , FromBackendRow be (table Identity) )
     => SqlDelete be table
     -> m [table Identity]
+  runDeleteReturningList sql = runDeleteReturningListWith sql id
 
 instance MonadBeamDeleteReturning be m => MonadBeamDeleteReturning be (ExceptT e m) where
-    runDeleteReturningList = lift . runDeleteReturningList
+    runDeleteReturningListWith sql proj = lift $ runDeleteReturningListWith sql proj
 instance MonadBeamDeleteReturning be m => MonadBeamDeleteReturning be (ContT r m) where
-    runDeleteReturningList = lift . runDeleteReturningList
+    runDeleteReturningListWith sql proj = lift $ runDeleteReturningListWith sql proj
 instance MonadBeamDeleteReturning be m => MonadBeamDeleteReturning be (ReaderT r m) where
-    runDeleteReturningList = lift . runDeleteReturningList
+    runDeleteReturningListWith sql proj = lift $ runDeleteReturningListWith sql proj
 instance MonadBeamDeleteReturning be m => MonadBeamDeleteReturning be (Lazy.StateT r m) where
-    runDeleteReturningList = lift . runDeleteReturningList
+    runDeleteReturningListWith sql proj = lift $ runDeleteReturningListWith sql proj
 instance MonadBeamDeleteReturning be m => MonadBeamDeleteReturning be (Strict.StateT r m) where
-    runDeleteReturningList = lift . runDeleteReturningList
+    runDeleteReturningListWith sql proj = lift $ runDeleteReturningListWith sql proj
 instance (MonadBeamDeleteReturning be m, Monoid r)
     => MonadBeamDeleteReturning be (Lazy.WriterT r m) where
-    runDeleteReturningList = lift . runDeleteReturningList
+    runDeleteReturningListWith sql proj = lift $ runDeleteReturningListWith sql proj
 instance (MonadBeamDeleteReturning be m, Monoid r)
     => MonadBeamDeleteReturning be (Strict.WriterT r m) where
-    runDeleteReturningList = lift . runDeleteReturningList
+    runDeleteReturningListWith sql proj = lift $ runDeleteReturningListWith sql proj
 instance (MonadBeamDeleteReturning be m, Monoid w)
     => MonadBeamDeleteReturning be (Lazy.RWST r w s m) where
-    runDeleteReturningList = lift . runDeleteReturningList
+    runDeleteReturningListWith sql proj = lift $ runDeleteReturningListWith sql proj
 instance (MonadBeamDeleteReturning be m, Monoid w)
     => MonadBeamDeleteReturning be (Strict.RWST r w s m) where
-    runDeleteReturningList = lift . runDeleteReturningList
+    runDeleteReturningListWith sql proj = lift $ runDeleteReturningListWith sql proj
 
 class BeamSqlBackend be => BeamHasInsertOnConflict be where
   -- | Specifies the kind of constraint that must be violated for the action to occur

--- a/beam-postgres/Database/Beam/Postgres/Connection.hs
+++ b/beam-postgres/Database/Beam/Postgres/Connection.hs
@@ -26,13 +26,13 @@ module Database.Beam.Postgres.Connection
   , postgresUriSyntax ) where
 
 import           Control.Exception (SomeException(..), throwIO)
-import           Data.IORef (newIORef, readIORef, writeIORef)
-import           Data.Vector (Vector)
-import qualified Data.Vector as V
 import           Control.Monad.Base (MonadBase(..))
 import           Control.Monad.Free.Church
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Control (MonadBaseControl(..))
+import           Data.IORef (newIORef, readIORef, writeIORef)
+import           Data.Vector (Vector)
+import qualified Data.Vector as V
 
 import           Database.Beam hiding (runDelete, runUpdate, runInsert, insert)
 import           Database.Beam.Backend.SQL.BeamExtensions
@@ -405,12 +405,11 @@ instance MonadBeam Postgres Pg where
           in collectM id
 
 instance MonadBeamInsertReturning Postgres Pg where
-    runInsertReturningList i = do
-        let insertReturningCmd' = i `returning`
-              changeBeamRep (\(Columnar' (QExpr s) :: Columnar' (QExpr Postgres PostgresInaccessible) ty) ->
-                Columnar' (QExpr s) :: Columnar' (QExpr Postgres ()) ty)
-
-        -- Make savepoint
+    runInsertReturningListWith i mkProjection = do
+        let pgProj tbl = mkProjection (changeBeamRep
+              (\(Columnar' (QExpr s) :: Columnar' (QExpr Postgres PostgresInaccessible) ty) ->
+                Columnar' (QExpr s) :: Columnar' (QExpr Postgres ()) ty) tbl)
+            insertReturningCmd' = i `returning` pgProj
         case insertReturningCmd' of
           PgInsertReturningEmpty ->
             pure []
@@ -418,11 +417,11 @@ instance MonadBeamInsertReturning Postgres Pg where
             runReturningList (PgCommandSyntax PgCommandTypeDataUpdateReturning insertReturningCmd)
 
 instance MonadBeamUpdateReturning Postgres Pg where
-    runUpdateReturningList u = do
-        let updateReturningCmd' = u `returning`
-              changeBeamRep (\(Columnar' (QExpr s) :: Columnar' (QExpr Postgres PostgresInaccessible) ty) ->
-                Columnar' (QExpr s) :: Columnar' (QExpr Postgres ()) ty)
-
+    runUpdateReturningListWith u mkProjection = do
+        let pgProj tbl = mkProjection (changeBeamRep
+              (\(Columnar' (QExpr s) :: Columnar' (QExpr Postgres PostgresInaccessible) ty) ->
+                Columnar' (QExpr s) :: Columnar' (QExpr Postgres ()) ty) tbl)
+            updateReturningCmd' = u `returning` pgProj
         case updateReturningCmd' of
           PgUpdateReturningEmpty ->
             pure []
@@ -430,9 +429,9 @@ instance MonadBeamUpdateReturning Postgres Pg where
             runReturningList (PgCommandSyntax PgCommandTypeDataUpdateReturning updateReturningCmd)
 
 instance MonadBeamDeleteReturning Postgres Pg where
-    runDeleteReturningList d = do
-        let PgDeleteReturning deleteReturningCmd = d `returning`
-              changeBeamRep (\(Columnar' (QExpr s) :: Columnar' (QExpr Postgres PostgresInaccessible) ty) ->
-                Columnar' (QExpr s) :: Columnar' (QExpr Postgres ()) ty)
-
+    runDeleteReturningListWith d mkProjection = do
+        let pgProj tbl = mkProjection (changeBeamRep
+              (\(Columnar' (QExpr s) :: Columnar' (QExpr Postgres PostgresInaccessible) ty) ->
+                Columnar' (QExpr s) :: Columnar' (QExpr Postgres ()) ty) tbl)
+            PgDeleteReturning deleteReturningCmd = d `returning` pgProj
         runReturningList (PgCommandSyntax PgCommandTypeDataUpdateReturning deleteReturningCmd)

--- a/beam-postgres/test/Database/Beam/Postgres/Test/DataTypes.hs
+++ b/beam-postgres/test/Database/Beam/Postgres/Test/DataTypes.hs
@@ -3,10 +3,10 @@
 module Database.Beam.Postgres.Test.DataTypes where
 
 import Database.Beam
+import Database.Beam.Backend.SQL.BeamExtensions
+import Database.Beam.Migrate
 import Database.Beam.Postgres
 import Database.Beam.Postgres.Test
-import Database.Beam.Migrate
-import Database.Beam.Backend.SQL.BeamExtensions
 
 import Control.Exception (SomeException(..), handle)
 
@@ -141,15 +141,15 @@ errorOnSchemaMismatch pgConn =
 -- | Regression test for <https://github.com/haskell-beam/beam/issues/700>
 errorOnLiteralDoubles :: IO ByteString -> TestTree
 errorOnLiteralDoubles pgConn =
-    testCase "Literal `Double`s are correctly specified as SQL `DOUBLE` (#700)" $ 
+    testCase "Literal `Double`s are correctly specified as SQL `DOUBLE` (#700)" $
     withTestPostgres "db_failures" pgConn $ \conn -> do
-      results <- runBeamPostgres conn $ 
-        runSelectReturningList $ 
-          select $ 
+      results <- runBeamPostgres conn $
+        runSelectReturningList $
+          select $
             query
-      
+
       results @?= [(99 :: Int32, 1.0 :: Double)]
-    
+
     where
       -- We need to provide a db for type-checking, but it will not be used
       query :: Q Postgres RealDb s (QExpr Postgres s Int32, QExpr Postgres s Double)

--- a/beam-postgres/test/Database/Beam/Postgres/Test/Marshal.hs
+++ b/beam-postgres/test/Database/Beam/Postgres/Test/Marshal.hs
@@ -52,7 +52,7 @@ boxGen = do PgPoint x1 y1 <- pointGen
                         (PgPoint (max x1 x2) (max y1 y2)))
 
 arrayGen :: Hedgehog.Gen a -> Hedgehog.Gen (Vector.Vector a)
-arrayGen = fmap Vector.fromList 
+arrayGen = fmap Vector.fromList
          . Gen.list (Range.linear 0 5) -- small arrays == quick tests
 
 boxCmp :: PgBox -> PgBox -> Bool
@@ -100,8 +100,8 @@ tests postgresConn =
 
     -- Arrays
     --
-    -- Testing lots of element types for arrays is important, because 
-    -- the mapping between array Oid and element Oid is not type 
+    -- Testing lots of element types for arrays is important, because
+    -- the mapping between array Oid and element Oid is not type
     -- safe, and hence error-prone.
     , marshalTest (arrayGen textGen) postgresConn
     , marshalTest (arrayGen (Gen.double (Range.exponentialFloat 0 1e40))) postgresConn

--- a/beam-sqlite/Database/Beam/Sqlite/Connection.hs
+++ b/beam-sqlite/Database/Beam/Sqlite/Connection.hs
@@ -16,11 +16,11 @@ module Database.Beam.Sqlite.Connection
 
     -- ** @INSERT ... RETURNING@
   , SqliteInsertReturning
-  , insertReturning, insertOnConflictReturning, runInsertReturningList
+  , insertReturning, insertOnConflictReturning, runSqliteInsertReturningList
 
     -- ** @DELETE ... RETURNING@
   , SqliteDeleteReturning
-  , deleteReturning, runDeleteReturningList
+  , deleteReturning, runSqliteDeleteReturningList
 
     -- ** @UPDATE ... RETURNING@
   , SqliteUpdateReturning
@@ -69,7 +69,7 @@ import           Database.SQLite.Simple.Ok (Ok(..))
 import           Database.SQLite.Simple.Types (Null)
 
 import           Control.Exception (SomeException(..))
-import           Control.Monad (forM_)
+import           Control.Monad (forM, forM_)
 import           Control.Monad.Base (MonadBase)
 import           Control.Monad.Fail (MonadFail(..))
 import           Control.Monad.Free.Church
@@ -386,20 +386,27 @@ unfoldM f = go []
     go acc = f >>= maybe (pure acc) (\x -> go (x : acc))
 
 instance Beam.MonadBeamInsertReturning Sqlite SqliteM where
-  runInsertReturningList SqlInsertNoRows = pure []
-  runInsertReturningList (SqlInsert _ insertCommand) = runReturningList $ SqliteCommandInsert insertCommand
+  runInsertReturningListWith SqlInsertNoRows _ = pure []
+  runInsertReturningListWith (SqlInsert tblSettings (SqliteInsertSyntax tbl fields values onConflict)) mkProjection =
+    fmap concat $ forM (sqliteGroupByDefaults fields values) $ \(fields', values') ->
+      runReturningList $ SqliteCommandSyntax $
+        formatSqliteInsertOnConflict tbl fields' values' onConflict
+        <> returningClauseWithProjection tblSettings mkProjection
 
 -- |
 -- @since 0.6.0.0
 instance Beam.MonadBeamUpdateReturning Sqlite SqliteM where
-  runUpdateReturningList :: forall table. (
-    Beamable table, Projectible Sqlite (table (QExpr Sqlite ())), FromBackendRow Sqlite (table Identity)
-    ) => SqlUpdate Sqlite table -> SqliteM [table Identity]
-  runUpdateReturningList SqlIdentityUpdate = pure []
-  runUpdateReturningList (SqlUpdate tblSettings sqliteUpdate) =
+  runUpdateReturningListWith SqlIdentityUpdate _ = pure []
+  runUpdateReturningListWith (SqlUpdate tblSettings sqliteUpdate) mkProjection =
     runReturningList $ SqliteCommandSyntax $
       fromSqliteUpdate sqliteUpdate
-        <> returningClauseWithProjection tblSettings (id :: table (QExpr Sqlite ()) -> table (QExpr Sqlite ()))
+        <> returningClauseWithProjection tblSettings mkProjection
+
+instance Beam.MonadBeamDeleteReturning Sqlite SqliteM where
+  runDeleteReturningListWith (SqlDelete tblSettings sqliteDelete) mkProjection =
+    runReturningList $ SqliteCommandSyntax $
+      fromSqliteDelete sqliteDelete
+        <> returningClauseWithProjection tblSettings mkProjection
 
 newtype SqliteInsertReturning a = SqliteInsertReturning [SqliteSyntax]
 newtype SqliteDeleteReturning a = SqliteDeleteReturning SqliteSyntax
@@ -445,14 +452,14 @@ sqliteGroupByDefaults flds orig@(SqliteInsertFromSql {}) =
   -- Preserve manually-written queries
   [(flds, orig)]
 
-runDeleteReturningList
+runSqliteDeleteReturningList
   :: ( MonadBeam be m
      , BeamSqlBackendSyntax be ~ SqliteCommandSyntax
      , FromBackendRow be a
      )
   => SqliteDeleteReturning a
   -> m [a]
-runDeleteReturningList (SqliteDeleteReturning syntax) =
+runSqliteDeleteReturningList (SqliteDeleteReturning syntax) =
   runReturningList $ SqliteCommandSyntax syntax
 
 -- | SQLite @DELETE ... RETURNING@ statement support. The last
@@ -549,14 +556,14 @@ insertOnConflictReturning
 
 -- | Runs a 'SqliteInsertReturning' statement and returns a result for each
 -- inserted row.
-runInsertReturningList
+runSqliteInsertReturningList
   :: ( MonadBeam be m
      , BeamSqlBackendSyntax be ~ SqliteCommandSyntax
      , FromBackendRow be a
      )
   => SqliteInsertReturning a
   -> m [a]
-runInsertReturningList (SqliteInsertReturning syntaxes) =
+runSqliteInsertReturningList (SqliteInsertReturning syntaxes) =
   concat <$>
     traverse (\syntax -> runReturningList $ SqliteCommandSyntax syntax) syntaxes
 

--- a/beam-sqlite/test/Database/Beam/Sqlite/Test/Insert.hs
+++ b/beam-sqlite/test/Database/Beam/Sqlite/Test/Insert.hs
@@ -5,7 +5,7 @@ import Data.Text (Text)
 import Data.Time (LocalTime, Day(..), UTCTime(..), fromGregorian, getCurrentTime, secondsToDiffTime)
 import Database.Beam
 import Database.Beam.Backend.SQL.BeamExtensions
-import Database.Beam.Sqlite hiding (runInsertReturningList)
+import Database.Beam.Sqlite
 import Database.SQLite.Simple (execute_)
 import Test.Tasty
 import Test.Tasty.ExpectedFailure

--- a/beam-sqlite/test/Database/Beam/Sqlite/Test/InsertOnConflictReturning.hs
+++ b/beam-sqlite/test/Database/Beam/Sqlite/Test/InsertOnConflictReturning.hs
@@ -8,6 +8,7 @@ module Database.Beam.Sqlite.Test.InsertOnConflictReturning (tests) where
 
 import Data.Int (Int32)
 import Data.Text (Text)
+import Database.Beam
 import Database.Beam (
     Beamable,
     Columnar,
@@ -31,26 +32,22 @@ import Database.Beam.Backend.SQL.BeamExtensions (
         insertOnConflict,
         onConflictUpdateSetWhere
     ),
-    MonadBeamInsertReturning (runInsertReturningList),
- )
-import Database.Beam.Sqlite (Sqlite, runBeamSqlite)
-import Database.Beam.Sqlite.Test (withTestDb)
-import Database.SQLite.Simple (execute_)
-import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (testCase, (@?=))
-
-import Database.Beam
-import Database.Beam.Backend.SQL.BeamExtensions (
     conflictingFields,
     insertOnConflict,
     onConflictUpdateSetWhere,
     runInsertReturningList,
+    runInsertReturningListWith,
  )
 import Database.Beam.Migrate (defaultMigratableDbSettings)
 import Database.Beam.Migrate.Simple (CheckedDatabaseSettings, autoMigrate)
+import Database.Beam.Sqlite (Sqlite, runBeamSqlite)
 import Database.Beam.Sqlite (Sqlite, runBeamSqliteDebug)
 import Database.Beam.Sqlite.Migrate (migrationBackend)
+import Database.Beam.Sqlite.Test (withTestDb)
+import Database.SQLite.Simple (execute_)
 import Database.SQLite.Simple (open)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@?=))
 
 tests :: TestTree
 tests =
@@ -112,8 +109,8 @@ testInsertOnConflictReturning = testCase "Check that conflicting values are retu
                         , User{userId = 2, userName = "different_user2"}
                         ]
 
-                runInsertReturningList $
-                    insertOnConflict
+                runInsertReturningListWith
+                    (insertOnConflict
                         (usersTable testDb)
                         (insertValues newUsers)
                         (conflictingFields userId)
@@ -126,7 +123,8 @@ testInsertOnConflictReturning = testCase "Check that conflicting values are retu
                                (User{userName = excl}) ->
                                     current_ fld /=. excl
                             )
-                        )
+                        ))
+                    userId
 
         -- Expecting that the conflicting user, User id 2, is also returned
-        userId <$> conflicts @?= [1, 2]
+        conflicts @?= [1, 2]

--- a/beam-sqlite/test/Database/Beam/Sqlite/Test/Returning.hs
+++ b/beam-sqlite/test/Database/Beam/Sqlite/Test/Returning.hs
@@ -15,20 +15,20 @@ import Test.Tasty.HUnit (testCase, (@?=))
 
 import Database.Beam
 import Database.Beam.Backend.SQL.BeamExtensions
-  (conflictingFields, onConflictUpdateSet, onConflictUpdateSetWhere, runUpdateReturningList)
+  ( conflictingFields, onConflictUpdateSetWhere
+  , runInsertReturningListWith, runUpdateReturningListWith, runDeleteReturningListWith
+  )
 import Database.Beam.Migrate (defaultMigratableDbSettings)
 import Database.Beam.Migrate.Simple (CheckedDatabaseSettings, autoMigrate)
-import Database.Beam.Sqlite (Sqlite, runBeamSqlite, insertOnConflictReturning)
+import Database.Beam.Sqlite (
+  Sqlite, runBeamSqlite
+  , insertOnConflictReturning
+  , runSqliteInsertReturningList
+  , runSqliteUpdateReturningList
+  , runSqliteDeleteReturningList
+  )
+import qualified Database.Beam.Sqlite as Sqlite (deleteReturning, insertReturning, updateReturning)
 import Database.Beam.Sqlite.Migrate (migrationBackend)
-
-import Database.Beam.Sqlite
-    ( deleteReturning
-    , insertReturning
-    , runDeleteReturningList
-    , runInsertReturningList
-    , runSqliteUpdateReturningList
-    , updateReturning
-    )
 
 import Database.Beam.Sqlite.Test (withTestDb)
 
@@ -39,8 +39,11 @@ tests =
         "SQLite RETURNING statement tests"
         [ testInsertOnConflictReturning
         , testSqliteUpdateReturning
-        , testUpdateReturning
         , testDeleteReturning
+
+        , testClassInsertReturning
+        , testClassUpdateReturning
+        , testClassDeleteReturning
         ]
 
 -- | Database Schema Definition
@@ -104,7 +107,7 @@ testInsertOnConflictReturning = testCase "INSERT .. ON CONFLICT .. RETURNING" $
             ]
 
         -- Run 'INSERT .. ON CONFLICT (id) DO UPDATE SET .. WHERE .. RETURNING ..'
-        runInsertReturningList $
+        runSqliteInsertReturningList $
           insertOnConflictReturning
             (usersTable testDb)
             (insertValues newUsers)
@@ -144,40 +147,13 @@ testSqliteUpdateReturning = testCase "UPDATE .. RETURNING" $
 
         -- Update user 2 and return projected columns from the updated row
         runSqliteUpdateReturningList $
-          updateReturning
+          Sqlite.updateReturning
             (usersTable testDb)
             (\u -> userName u <-. val_ "updated_user2")
             (\u -> userId u ==. val_ 2)
             (\u -> (userId u, userName u, userInfo2 u))
 
     updatedUsers @?= [(2, "updated_user2", 22)]
-
--- | Test @UPDATE ... RETURNING@ using MonadBeamUpdateReturning's runUpdateReturningList
-testUpdateReturning :: TestTree
-testUpdateReturning = testCase "UPDATE .. RETURNING" $
-  withTestDb $ \conn -> do
-    updatedUsers <-
-      runBeamSqlite conn $ do
-        autoMigrate migrationBackend checkedDb
-
-        -- Seed data
-        runInsert $
-          insert (usersTable testDb) $
-            insertValues
-              [ User {userId = 1, userName = "user1", userInfo1 = "user1Info1", userInfo2 = 11 }
-              , User {userId = 2, userName = "user2", userInfo1 = "user2Info1", userInfo2 = 22 }
-              , User {userId = 3, userName = "user3", userInfo1 = "user3Info1", userInfo2 = 33 }
-              ]
-
-        -- Update user 2 and return projected columns from the updated row
-        runUpdateReturningList $
-          update
-            (usersTable testDb)
-            (\u -> userName u <-. val_ "updated_user2")
-            (\u -> userId u ==. val_ 2)
-
-
-    fmap (\u -> (userId u, userName u, userInfo2 u)) updatedUsers @?= [(2, "updated_user2", 22)]
 
 -- | Test @DELETE .. RETURNING@
 testDeleteReturning :: TestTree
@@ -197,10 +173,65 @@ testDeleteReturning = testCase "DELETE .. RETURNING" $
               ]
 
         -- Delete user 3 and return projected columns from the deleted row
-        runDeleteReturningList $
-          deleteReturning
+        runSqliteDeleteReturningList $
+          Sqlite.deleteReturning
             (usersTable testDb)
             (\u -> userId u ==. val_ 3)
             (\u -> (userName u, userInfo2 u))
 
     deletedUsers @?= [("user3", 33)]
+
+-- | Test class-level @INSERT .. RETURNING@ with custom projection
+testClassInsertReturning :: TestTree
+testClassInsertReturning = testCase "Class INSERT .. RETURNING" $
+  withTestDb $ \conn -> do
+    results <-
+      runBeamSqlite conn $ do
+        autoMigrate migrationBackend checkedDb
+        runInsertReturningListWith
+          (insert (usersTable testDb) $
+            insertValues
+              [ User {userId = 1, userName = "user1", userInfo1 = "info1", userInfo2 = 11 }
+              , User {userId = 2, userName = "user2", userInfo1 = "info2", userInfo2 = 22 }
+              ])
+          (\u -> (userId u, userName u))
+    results @?= [(1, "user1"), (2, "user2")]
+
+-- | Test class-level @UPDATE .. RETURNING@ with custom projection
+testClassUpdateReturning :: TestTree
+testClassUpdateReturning = testCase "Class UPDATE .. RETURNING" $
+  withTestDb $ \conn -> do
+    results <-
+      runBeamSqlite conn $ do
+        autoMigrate migrationBackend checkedDb
+        runInsert $
+          insert (usersTable testDb) $
+            insertValues
+              [ User {userId = 1, userName = "user1", userInfo1 = "info1", userInfo2 = 11 }
+              , User {userId = 2, userName = "user2", userInfo1 = "info2", userInfo2 = 22 }
+              ]
+        runUpdateReturningListWith
+          (update (usersTable testDb)
+            (\u -> userName u <-. val_ "updated")
+            (\u -> userId u ==. val_ 2))
+          (\u -> (userId u, userName u))
+    results @?= [(2, "updated")]
+
+-- | Test class-level @DELETE .. RETURNING@ with custom projection
+testClassDeleteReturning :: TestTree
+testClassDeleteReturning = testCase "Class DELETE .. RETURNING" $
+  withTestDb $ \conn -> do
+    results <-
+      runBeamSqlite conn $ do
+        autoMigrate migrationBackend checkedDb
+        runInsert $
+          insert (usersTable testDb) $
+            insertValues
+              [ User {userId = 1, userName = "user1", userInfo1 = "info1", userInfo2 = 11 }
+              , User {userId = 2, userName = "user2", userInfo1 = "info2", userInfo2 = 22 }
+              ]
+        runDeleteReturningListWith
+          (delete (usersTable testDb)
+            (\u -> userId u ==. val_ 2))
+          (\u -> (userName u, userInfo2 u))
+    results @?= [("user2", 22)]


### PR DESCRIPTION
(Redux of #800.)

This implements the idea from https://github.com/haskell-beam/beam/issues/775 and closes that issue.

I realized that in #799, I probably should have done `MonadBeamInsertReturning` and `MonadBeamDeleteReturning` as well...