### PR TITLE
Remove ghc-prim dependency from beam-core

### DIFF
--- a/beam-core/ChangeLog.md
+++ b/beam-core/ChangeLog.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+## Dependencies
+
+* Removed dependency on `ghc-prim`.
 
 # 0.11.0.0
 

--- a/beam-core/Database/Beam/Backend/Types.hs
+++ b/beam-core/Database/Beam/Backend/Types.hs
@@ -6,8 +6,8 @@ module Database.Beam.Backend.Types
   , Exposed, Nullable
 
   ) where
+import Data.Kind (Type, Constraint)
 
-import GHC.Types
 
 -- | Class for all Beam backends
 class BeamBackend be where

--- a/beam-core/Database/Beam/Query/CTE.hs
+++ b/beam-core/Database/Beam/Query/CTE.hs
@@ -10,7 +10,7 @@ import Database.Beam.Query.Types
 
 import Control.Monad.Fix
 import Control.Monad.Free.Church
-import Control.Monad.Writer hiding ((<>))
+import Control.Monad.Writer (WriterT, tell)
 import Control.Monad.State.Strict
 
 import Data.Kind (Type)

--- a/beam-core/Database/Beam/Query/Internal.hs
+++ b/beam-core/Database/Beam/Query/Internal.hs
@@ -9,6 +9,7 @@ import           Database.Beam.Schema.Tables
 
 import qualified Data.DList as DList
 import           Data.Functor.Const
+import           Data.Kind (Type, Constraint)
 import           Data.String
 import qualified Data.Text as T
 import           Data.Typeable
@@ -20,7 +21,6 @@ import           Control.Monad.State
 import           Control.Monad.Writer
 
 import           GHC.TypeLits
-import           GHC.Types
 
 import           Unsafe.Coerce
 

--- a/beam-core/Database/Beam/Schema/Tables.hs
+++ b/beam-core/Database/Beam/Schema/Tables.hs
@@ -79,10 +79,11 @@ import           Database.Beam.Backend.Types
 import           Control.Applicative (liftA2)
 import           Control.Arrow (first)
 import           Control.Monad.Identity
-import           Control.Monad.Writer hiding ((<>))
+import           Control.Monad.Writer (Writer, execWriter, tell)
 
 import           Data.Char (isUpper, toLower)
 import           Data.Foldable (fold)
+import           Data.Kind (Type, Constraint)
 import qualified Data.List.NonEmpty as NE
 import           Data.Monoid
 import           Data.Proxy
@@ -94,7 +95,6 @@ import           Data.Typeable
 import qualified GHC.Generics as Generic
 import           GHC.Generics hiding (R, C)
 import           GHC.TypeLits
-import           GHC.Types
 
 import           Lens.Micro hiding (to)
 

--- a/beam-core/beam-core.cabal
+++ b/beam-core/beam-core.cabal
@@ -63,7 +63,6 @@ library
                        bytestring   >=0.10    && <0.13,
                        mtl          >=2.2.1   && <2.4,
                        microlens    >=0.4     && <0.6,
-                       ghc-prim     >=0.5     && <0.14,
                        free         >=4.12    && <5.3,
                        dlist        >=0.7.1.2 && <1.1,
                        time         >=1.6     && <1.15,


### PR DESCRIPTION
`ghc-prim` was used to pull in types that are now part of `Data.Kind`.