### PR TITLE
`BeamHasInsertOnConflict` instance for DuckDB

### DIFF
--- a/beam-duckdb/CHANGELOG.md
+++ b/beam-duckdb/CHANGELOG.md
@@ -9,6 +9,20 @@
   build the per-format options records. See
   `Database.Beam.DuckDB.Syntax.Extensions.Copy`.
 * Added instances for `MonadBeamInsertReturning` / `MonadBeamUpdateReturning` / `MonadBeamDeleteReturning`;
+* Added a `BeamHasInsertOnConflict DuckDB` instance, exposing
+  `insertOnConflict` (and the `anyConflict` / `conflictingFields` /
+  `onConflictDoNothing` / `onConflictUpdateSet` /
+  `onConflictUpdateSetWhere` / `onConflictUpdateAll` /
+  `onConflictUpdateInstead` combinators) for `INSERT ... ON CONFLICT`
+  on DuckDB. DuckDB does not support partial-index conflict targets
+  ([INSERT docs](https://duckdb.org/docs/stable/sql/statements/insert),
+  so `conflictingFieldsWhere` is *not* re-exported from
+  `Database.Beam.DuckDB`; the `conflictingFieldsWhere` in that module
+  is a shadowing shim that produces a compile-time `TypeError`
+  pointing users at `onConflictUpdateSetWhere`. Importing
+  `conflictingFieldsWhere` directly from
+  `Database.Beam.Backend.SQL.BeamExtensions` still type-checks but
+  raises an error at runtime.
 
 ## 0.3.0.0 -- 2026-04-28
 

--- a/beam-duckdb/beam-duckdb.cabal
+++ b/beam-duckdb/beam-duckdb.cabal
@@ -46,6 +46,7 @@ library
                       Database.Beam.DuckDB.Syntax.Extensions
                       Database.Beam.DuckDB.Syntax.Extensions.Copy
                       Database.Beam.DuckDB.Syntax.Extensions.DataSource
+                      Database.Beam.DuckDB.Syntax.Extensions.InsertOnConflict
     build-depends:    base >=4.11 && <5
                     , beam-core >=0.11.1 && <0.12
                     , beam-migrate ^>=0.6
@@ -67,6 +68,7 @@ test-suite beam-duckdb-test
     other-modules:    Database.Beam.DuckDB.Test.Extensions
                       Database.Beam.DuckDB.Test.Extensions.Copy
                       Database.Beam.DuckDB.Test.Extensions.DataSource
+                      Database.Beam.DuckDB.Test.Extensions.InsertOnConflict
                       Database.Beam.DuckDB.Test.Extensions.Returning
                       Database.Beam.DuckDB.Test.Query
     type:             exitcode-stdio-1.0

--- a/beam-duckdb/src/Database/Beam/DuckDB.hs
+++ b/beam-duckdb/src/Database/Beam/DuckDB.hs
@@ -50,19 +50,7 @@ module Database.Beam.DuckDB
     -- class method is /not/ re-exported here. The 'conflictingFieldsWhere'
     -- in scope is a compile-time-blocked shim that produces a 'TypeError'
     -- when used — pointing users at 'onConflictUpdateSetWhere' instead.
-    BeamHasInsertOnConflict
-      ( SqlConflictTarget,
-        SqlConflictAction,
-        insertOnConflict,
-        anyConflict,
-        conflictingFields,
-        onConflictDoNothing,
-        onConflictUpdateSet,
-        onConflictUpdateSetWhere
-      ),
-    conflictingFieldsWhere,
-    onConflictUpdateAll,
-    onConflictUpdateInstead,
+    module Database.Beam.DuckDB.Syntax.Extensions.InsertOnConflict,
 
     -- * DuckDB-specific functionality
 
@@ -127,21 +115,9 @@ module Database.Beam.DuckDB
 where
 
 import Database.Beam.Backend.SQL.BeamExtensions
-  ( BeamHasInsertOnConflict
-      ( SqlConflictAction,
-        SqlConflictTarget,
-        anyConflict,
-        conflictingFields,
-        insertOnConflict,
-        onConflictDoNothing,
-        onConflictUpdateSet,
-        onConflictUpdateSetWhere
-      ),
-    MonadBeamDeleteReturning (..),
+  ( MonadBeamDeleteReturning (..),
     MonadBeamInsertReturning (..),
     MonadBeamUpdateReturning (..),
-    onConflictUpdateAll,
-    onConflictUpdateInstead,
     runDeleteReturningList,
     runInsertReturningList,
     runUpdateReturningList,
@@ -186,5 +162,3 @@ import Database.Beam.DuckDB.Syntax.Extensions.Copy
   )
 import Database.Beam.DuckDB.Syntax.Extensions.DataSource
 import Database.Beam.DuckDB.Syntax.Extensions.InsertOnConflict
-  ( conflictingFieldsWhere,
-  )

--- a/beam-duckdb/src/Database/Beam/DuckDB.hs
+++ b/beam-duckdb/src/Database/Beam/DuckDB.hs
@@ -36,6 +36,34 @@ module Database.Beam.DuckDB
     MonadBeamDeleteReturning (..),
     runDeleteReturningList,
 
+    -- * @INSERT ... ON CONFLICT@ support
+
+    -- | The 'BeamHasInsertOnConflict' instance for DuckDB exposes
+    -- @INSERT ... ON CONFLICT@ via 'insertOnConflict', allowing rows that
+    -- violate a uniqueness constraint to be ignored
+    -- ('onConflictDoNothing') or replaced with new values
+    -- ('onConflictUpdateSet', 'onConflictUpdateAll',
+    -- 'onConflictUpdateInstead').
+    --
+    -- DuckDB does not support partial-index conflict targets, so the
+    -- 'Database.Beam.Backend.SQL.BeamExtensions.conflictingFieldsWhere'
+    -- class method is /not/ re-exported here. The 'conflictingFieldsWhere'
+    -- in scope is a compile-time-blocked shim that produces a 'TypeError'
+    -- when used — pointing users at 'onConflictUpdateSetWhere' instead.
+    BeamHasInsertOnConflict
+      ( SqlConflictTarget,
+        SqlConflictAction,
+        insertOnConflict,
+        anyConflict,
+        conflictingFields,
+        onConflictDoNothing,
+        onConflictUpdateSet,
+        onConflictUpdateSetWhere
+      ),
+    conflictingFieldsWhere,
+    onConflictUpdateAll,
+    onConflictUpdateInstead,
+
     -- * DuckDB-specific functionality
 
     -- ** Data sources
@@ -99,9 +127,21 @@ module Database.Beam.DuckDB
 where
 
 import Database.Beam.Backend.SQL.BeamExtensions
-  ( MonadBeamDeleteReturning (..),
+  ( BeamHasInsertOnConflict
+      ( SqlConflictAction,
+        SqlConflictTarget,
+        anyConflict,
+        conflictingFields,
+        insertOnConflict,
+        onConflictDoNothing,
+        onConflictUpdateSet,
+        onConflictUpdateSetWhere
+      ),
+    MonadBeamDeleteReturning (..),
     MonadBeamInsertReturning (..),
     MonadBeamUpdateReturning (..),
+    onConflictUpdateAll,
+    onConflictUpdateInstead,
     runDeleteReturningList,
     runInsertReturningList,
     runUpdateReturningList,
@@ -145,3 +185,6 @@ import Database.Beam.DuckDB.Syntax.Extensions.Copy
     defaultDuckDBParquetCopyToOptions,
   )
 import Database.Beam.DuckDB.Syntax.Extensions.DataSource
+import Database.Beam.DuckDB.Syntax.Extensions.InsertOnConflict
+  ( conflictingFieldsWhere,
+  )

--- a/beam-duckdb/src/Database/Beam/DuckDB/Syntax.hs
+++ b/beam-duckdb/src/Database/Beam/DuckDB/Syntax.hs
@@ -19,6 +19,7 @@ module Database.Beam.DuckDB.Syntax
     DuckDBDeleteSyntax (..),
     DuckDBTableNameSyntax (..),
     DuckDBOnConflictSyntax (..),
+    DuckDBFieldNameSyntax (..),
   )
 where
 

--- a/beam-duckdb/src/Database/Beam/DuckDB/Syntax/Extensions.hs
+++ b/beam-duckdb/src/Database/Beam/DuckDB/Syntax/Extensions.hs
@@ -30,6 +30,7 @@ import Database.Beam.DuckDB.Syntax
     DuckDBUpdateSyntax (..),
   )
 import Database.Beam.DuckDB.Syntax.Builder (DuckDBSyntax, commas, emit)
+import Database.Beam.DuckDB.Syntax.Extensions.InsertOnConflict ()
 import Database.Beam.Query (SqlDelete (..), SqlInsert (..), SqlUpdate (..))
 import Database.Beam.Query.Internal (Projectible, QExpr, QGenExpr (..), project)
 import Database.Beam.Schema.Tables (Columnar' (..), changeBeamRep, _fieldName)

--- a/beam-duckdb/src/Database/Beam/DuckDB/Syntax/Extensions/InsertOnConflict.hs
+++ b/beam-duckdb/src/Database/Beam/DuckDB/Syntax/Extensions/InsertOnConflict.hs
@@ -1,0 +1,221 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Database.Beam.DuckDB.Syntax.Extensions.InsertOnConflict
+  ( -- * Compile-time-blocked variant of 'conflictingFieldsWhere'
+
+    -- DuckDB does not support partial-index conflict targets, so calling
+    -- the class method 'Database.Beam.Backend.SQL.BeamExtensions.conflictingFieldsWhere'
+    -- against DuckDB results in a DuckDB binder error at execute time. The
+    -- 'conflictingFieldsWhere' exported here shadows the class method so
+    -- that any DuckDB user of @Database.Beam.DuckDB@ gets a /compile-time/
+    -- error instead — pointing them at 'onConflictUpdateSetWhere'.
+    conflictingFieldsWhere,
+    UnsupportedConflictingFieldsWhereOnDuckDB,
+  )
+where
+
+import Data.Proxy (Proxy (..))
+import Database.Beam (Beamable, TableEntity)
+import Database.Beam.Backend.SQL
+  ( IsSql92ExpressionSyntax (..),
+    IsSql92FieldNameSyntax (..),
+    IsSql92InsertSyntax (..),
+    IsSql92TableNameSyntax (..),
+  )
+import Database.Beam.Backend.SQL.BeamExtensions
+  ( BeamHasInsertOnConflict (SqlConflictAction, SqlConflictTarget),
+  )
+import qualified Database.Beam.Backend.SQL.BeamExtensions as Beam
+import Database.Beam.DuckDB.Backend (DuckDB)
+import Database.Beam.DuckDB.Syntax
+  ( DuckDBExpressionSyntax (..),
+    DuckDBFieldNameSyntax (..),
+    DuckDBInsertSyntax (..),
+  )
+import Database.Beam.DuckDB.Syntax.Builder
+  ( DuckDBSyntax,
+    commas,
+    emit,
+    parens,
+  )
+import Database.Beam.Query (SqlInsert (..), SqlInsertValues (..))
+import Database.Beam.Query.Internal
+  ( Projectible,
+    QAssignment (..),
+    QExpr,
+    QField (..),
+    QGenExpr (..),
+    QInternal,
+    project,
+  )
+import Database.Beam.Schema.Tables
+  ( Columnar' (..),
+    DatabaseEntity (..),
+    DatabaseEntityDescriptor (..),
+    TableField,
+    allBeamValues,
+    changeBeamRep,
+    _fieldName,
+  )
+import GHC.TypeLits (ErrorMessage (..), TypeError)
+
+-- | @since 0.3.1.0
+instance Beam.BeamHasInsertOnConflict DuckDB where
+  newtype SqlConflictTarget DuckDB table = DuckDBConflictTarget
+    {unDuckDBConflictTarget :: table (QExpr DuckDB QInternal) -> DuckDBSyntax}
+  newtype SqlConflictAction DuckDB table = DuckDBConflictAction
+    {unDuckDBConflictAction :: forall s. table (QField s) -> DuckDBSyntax}
+
+  insertOnConflict ::
+    forall table db s.
+    (Beamable table) =>
+    DatabaseEntity DuckDB db (TableEntity table) ->
+    SqlInsertValues DuckDB (table (QExpr DuckDB s)) ->
+    SqlConflictTarget DuckDB table ->
+    SqlConflictAction DuckDB table ->
+    SqlInsert DuckDB table
+  insertOnConflict (DatabaseEntity dt) values target action = case values of
+    SqlInsertValuesEmpty -> SqlInsertNoRows
+    SqlInsertValues vs ->
+      let tblSettings = dbTableSettings dt
+          mkField ::
+            forall a.
+            Columnar' (TableField table) a ->
+            Columnar' (QField QInternal) a
+          mkField (Columnar' fd) = Columnar' $ QField False (dbTableCurrentName dt) (_fieldName fd)
+          tblFields = changeBeamRep mkField tblSettings
+          tblExprs =
+            changeBeamRep
+              ( \(Columnar' (QField _ _ nm)) ->
+                  Columnar' (QExpr (\_ -> fieldE (unqualifiedField nm)))
+              )
+              tblFields
+          fieldList = allBeamValues (\(Columnar' f) -> _fieldName f) tblSettings
+          DuckDBInsertSyntax baseInsert =
+            insertStmt (tableName (dbTableSchema dt) (dbTableCurrentName dt)) fieldList vs
+       in SqlInsert tblSettings $
+            DuckDBInsertSyntax $
+              baseInsert
+                <> emit " ON CONFLICT "
+                <> unDuckDBConflictTarget target tblExprs
+                <> unDuckDBConflictAction action tblFields
+
+  anyConflict = DuckDBConflictTarget (const mempty)
+
+  conflictingFields makeProjection =
+    DuckDBConflictTarget $ \tbl ->
+      parens
+        ( commas $
+            map fromDuckDBExpression $
+              project (Proxy @DuckDB) (makeProjection tbl) "t"
+        )
+        <> emit " "
+
+  -- \| DuckDB does not support partial-index conflict targets, so calling this is always a bug.
+  -- The supported way to invoke this method from @Database.Beam.DuckDB@ goes through the shadowing
+  -- 'conflictingFieldsWhere' below, which produces a /compile-time/ error pointing users at 'onConflictUpdateSetWhere'.
+  conflictingFieldsWhere _ _ =
+    error
+      "Database.Beam.DuckDB: `conflictingFieldsWhere` is not supported on DuckDB. \
+      \DuckDB does not support partial-index conflict targets — use \
+      \`onConflictUpdateSetWhere` to filter the rows that are updated instead."
+
+  onConflictDoNothing = DuckDBConflictAction (const (emit "DO NOTHING"))
+
+  onConflictUpdateSet mkAssignments =
+    DuckDBConflictAction $ \tbl ->
+      let QAssignment assignments = mkAssignments tbl (excluded tbl)
+          assignmentSyntaxes =
+            [ fromDuckDBFieldName fieldNm
+                <> emit "="
+                <> parens (fromDuckDBExpression expr)
+            | (fieldNm, expr) <- assignments
+            ]
+       in emit "DO UPDATE SET " <> commas assignmentSyntaxes
+
+  onConflictUpdateSetWhere mkAssignments where_ =
+    DuckDBConflictAction $ \tbl ->
+      let QAssignment assignments = mkAssignments tbl (excluded tbl)
+          QExpr where_' = where_ tbl (excluded tbl)
+          assignmentSyntaxes =
+            [ fromDuckDBFieldName fieldNm
+                <> emit "="
+                <> parens (fromDuckDBExpression expr)
+            | (fieldNm, expr) <- assignments
+            ]
+       in emit "DO UPDATE SET "
+            <> commas assignmentSyntaxes
+            <> emit " WHERE "
+            <> fromDuckDBExpression (where_' "t")
+
+-- | Build a table reference whose fields point to the special @excluded@
+-- pseudo-table available inside DuckDB's @ON CONFLICT DO UPDATE@ — i.e. the
+-- row that would have been inserted had there been no conflict.
+excluded ::
+  (Beamable table) =>
+  table (QField s) ->
+  table (QExpr DuckDB s)
+excluded =
+  changeBeamRep
+    ( \(Columnar' (QField _ _ nm)) ->
+        Columnar' (QExpr (\_ -> fieldE (qualifiedField "excluded" nm)))
+    )
+
+-- | A class with a single 'TypeError'-guarded instance, used purely to
+-- defer firing of the type error until a /use site/ of
+-- 'conflictingFieldsWhere'. The instance context is only discharged
+-- when GHC actually selects this instance, which means defining a
+-- method body in terms of it (as @'conflictingFieldsWhere' = …@) does
+-- not trip the error at module load time.
+--
+-- = References
+--
+-- DuckDB's binder unconditionally rejects @ON CONFLICT (cols) WHERE …@:
+-- see @GenerateMergeInto@ in
+-- <https://github.com/duckdb/duckdb/blob/main/src/planner/binder/statement/bind_insert.cpp duckdb/duckdb \@ src\/planner\/binder\/statement\/bind_insert.cpp>,
+-- which throws @"ON CONFLICT WHERE clause is only supported in DO UPDATE
+-- SET ... WHERE ... The WHERE clause after the conflict columns is used
+-- for partial indexes which are not supported."@. The user-facing
+-- <https://duckdb.org/docs/stable/sql/statements/insert INSERT docs>
+-- describe both @WHERE@ positions, but only the trailing-update form
+-- actually binds; the index-predicate form (used in PostgreSQL to
+-- arbitrate between /partial/ unique indexes) has nothing to match
+-- against in DuckDB.
+--
+-- @since 0.3.1.0
+class UnsupportedConflictingFieldsWhereOnDuckDB where
+  -- | A 'conflictingFieldsWhere' that always fails to compile when
+  -- used against DuckDB. Re-exported from "Database.Beam.DuckDB" so
+  -- that it shadows the class method of the same name from
+  -- "Database.Beam.Backend.SQL.BeamExtensions".
+  --
+  -- @since 0.3.1.0
+  conflictingFieldsWhere ::
+    forall table proj.
+    (Projectible DuckDB proj, Beamable table) =>
+    (table (QExpr DuckDB QInternal) -> proj) ->
+    (forall s. table (QExpr DuckDB s) -> QExpr DuckDB s Bool) ->
+    SqlConflictTarget DuckDB table
+
+instance
+  (TypeError DuckDBConflictingFieldsWhereError) =>
+  UnsupportedConflictingFieldsWhereOnDuckDB
+  where
+  conflictingFieldsWhere _ _ = error "unreachable: TypeError fires first"
+
+type DuckDBConflictingFieldsWhereError =
+  'Text "`conflictingFieldsWhere` is not supported on the DuckDB backend."
+    ':$$: 'Text "DuckDB does not support partial-index conflict targets"
+    ':$$: 'Text "(the WHERE clause between the conflict columns and DO)."
+    ':$$: 'Text "Use `onConflictUpdateSetWhere` to filter the rows that are updated instead."

--- a/beam-duckdb/src/Database/Beam/DuckDB/Syntax/Extensions/InsertOnConflict.hs
+++ b/beam-duckdb/src/Database/Beam/DuckDB/Syntax/Extensions/InsertOnConflict.hs
@@ -12,15 +12,19 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Database.Beam.DuckDB.Syntax.Extensions.InsertOnConflict
-  ( -- * Compile-time-blocked variant of 'conflictingFieldsWhere'
-
-    -- DuckDB does not support partial-index conflict targets, so calling
-    -- the class method 'Database.Beam.Backend.SQL.BeamExtensions.conflictingFieldsWhere'
-    -- against DuckDB results in a DuckDB binder error at execute time. The
-    -- 'conflictingFieldsWhere' exported here shadows the class method so
-    -- that any DuckDB user of @Database.Beam.DuckDB@ gets a /compile-time/
-    -- error instead — pointing them at 'onConflictUpdateSetWhere'.
+  ( BeamHasInsertOnConflict
+      ( SqlConflictTarget,
+        SqlConflictAction,
+        insertOnConflict,
+        anyConflict,
+        conflictingFields,
+        onConflictDoNothing,
+        onConflictUpdateSet,
+        onConflictUpdateSetWhere
+      ),
     conflictingFieldsWhere,
+    onConflictUpdateAll,
+    onConflictUpdateInstead,
     UnsupportedConflictingFieldsWhereOnDuckDB,
   )
 where
@@ -35,6 +39,8 @@ import Database.Beam.Backend.SQL
   )
 import Database.Beam.Backend.SQL.BeamExtensions
   ( BeamHasInsertOnConflict (SqlConflictAction, SqlConflictTarget),
+    onConflictUpdateAll,
+    onConflictUpdateInstead,
   )
 import qualified Database.Beam.Backend.SQL.BeamExtensions as Beam
 import Database.Beam.DuckDB.Backend (DuckDB)

--- a/beam-duckdb/tests/Database/Beam/DuckDB/Test/Extensions.hs
+++ b/beam-duckdb/tests/Database/Beam/DuckDB/Test/Extensions.hs
@@ -2,6 +2,7 @@ module Database.Beam.DuckDB.Test.Extensions (tests) where
 
 import qualified Database.Beam.DuckDB.Test.Extensions.Copy as Copy
 import qualified Database.Beam.DuckDB.Test.Extensions.DataSource as DataSource
+import qualified Database.Beam.DuckDB.Test.Extensions.InsertOnConflict as InsertOnConflict
 import qualified Database.Beam.DuckDB.Test.Extensions.Returning as Returning
 import Test.Tasty (TestTree, testGroup)
 
@@ -11,5 +12,6 @@ tests =
     "Extensions"
     [ Copy.tests,
       DataSource.tests,
+      InsertOnConflict.tests,
       Returning.tests
     ]

--- a/beam-duckdb/tests/Database/Beam/DuckDB/Test/Extensions/InsertOnConflict.hs
+++ b/beam-duckdb/tests/Database/Beam/DuckDB/Test/Extensions/InsertOnConflict.hs
@@ -1,0 +1,306 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Database.Beam.DuckDB.Test.Extensions.InsertOnConflict (tests) where
+
+import Control.Monad (void)
+import Data.Int (Int32)
+import qualified Data.List as List
+import Data.Text (Text)
+import Database.Beam
+  ( Beamable,
+    Columnar,
+    Database,
+    DatabaseSettings,
+    Generic,
+    Identity,
+    SqlOrd ((>.)),
+    Table (..),
+    TableEntity,
+    all_,
+    asc_,
+    current_,
+    dbModification,
+    defaultDbSettings,
+    insert,
+    insertValues,
+    modifyTableFields,
+    orderBy_,
+    runInsert,
+    runSelectReturningList,
+    select,
+    tableModification,
+    val_,
+    withDbModification,
+    (<-.),
+  )
+import Database.Beam.DuckDB
+  ( BeamHasInsertOnConflict
+      ( anyConflict,
+        conflictingFields,
+        insertOnConflict,
+        onConflictDoNothing,
+        onConflictUpdateSet,
+        onConflictUpdateSetWhere
+      ),
+    DuckDB,
+    onConflictUpdateAll,
+    onConflictUpdateInstead,
+    runBeamDuckDB,
+    runInsertReturningList,
+  )
+import Database.DuckDB.Simple (Connection, execute_, withConnection)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@?=))
+
+tests :: TestTree
+tests =
+  testGroup
+    "INSERT ... ON CONFLICT"
+    [ testAnyConflictDoNothing,
+      testConflictingFieldsDoNothing,
+      testConflictingFieldsUpdateAll,
+      testConflictingFieldsUpdateInstead,
+      testConflictingFieldsUpdateSet,
+      testConflictingFieldsUpdateSetWhere,
+      testInsertOnConflictReturning
+    ]
+
+testAnyConflictDoNothing :: TestTree
+testAnyConflictDoNothing =
+  testCase "anyConflict + onConflictDoNothing leaves existing rows untouched" $
+    withTestDb widgetData $ \conn -> do
+      runBeamDuckDB conn $
+        runInsert $
+          insertOnConflict
+            (_dbWidgets testDb)
+            (insertValues [Widget 2 "Sprocket-collision" 0.0])
+            anyConflict
+            onConflictDoNothing
+      remaining <- queryAllWidgets conn
+      remaining @?= List.sortOn _widgetId widgetData
+
+testConflictingFieldsDoNothing :: TestTree
+testConflictingFieldsDoNothing =
+  testCase "conflictingFields + onConflictDoNothing inserts non-conflicting rows" $
+    withTestDb widgetData $ \conn -> do
+      runBeamDuckDB conn $
+        runInsert $
+          insertOnConflict
+            (_dbWidgets testDb)
+            ( insertValues
+                [ Widget 2 "Sprocket-collision" 0.0,
+                  Widget 4 "Gear" 7.75
+                ]
+            )
+            (conflictingFields _widgetId)
+            onConflictDoNothing
+      remaining <- queryAllWidgets conn
+      remaining
+        @?= [ Widget 1 "Widget" 9.99,
+              Widget 2 "Sprocket" 4.50,
+              Widget 3 "Cog" 1.25,
+              Widget 4 "Gear" 7.75
+            ]
+
+testConflictingFieldsUpdateAll :: TestTree
+testConflictingFieldsUpdateAll =
+  testCase "conflictingFields + onConflictUpdateAll overwrites every column" $
+    withTestDb widgetData $ \conn -> do
+      runBeamDuckDB conn $
+        runInsert $
+          insertOnConflict
+            (_dbWidgets testDb)
+            ( insertValues
+                [ Widget 2 "Sprocket-v2" 6.00,
+                  Widget 4 "Gear" 7.75
+                ]
+            )
+            (conflictingFields _widgetId)
+            onConflictUpdateAll
+      remaining <- queryAllWidgets conn
+      remaining
+        @?= [ Widget 1 "Widget" 9.99,
+              Widget 2 "Sprocket-v2" 6.00,
+              Widget 3 "Cog" 1.25,
+              Widget 4 "Gear" 7.75
+            ]
+
+testConflictingFieldsUpdateInstead :: TestTree
+testConflictingFieldsUpdateInstead =
+  testCase "conflictingFields + onConflictUpdateInstead overwrites a subset" $
+    withTestDb widgetData $ \conn -> do
+      runBeamDuckDB conn $
+        runInsert $
+          insertOnConflict
+            (_dbWidgets testDb)
+            (insertValues [Widget 2 "Sprocket-v3" 100.0])
+            (conflictingFields _widgetId)
+            (onConflictUpdateInstead _widgetName)
+      remaining <- queryAllWidgets conn
+      remaining
+        @?= [ Widget 1 "Widget" 9.99,
+              Widget 2 "Sprocket-v3" 4.50,
+              Widget 3 "Cog" 1.25
+            ]
+
+testConflictingFieldsUpdateSet :: TestTree
+testConflictingFieldsUpdateSet =
+  testCase "conflictingFields + onConflictUpdateSet applies a custom assignment" $
+    withTestDb widgetData $ \conn -> do
+      runBeamDuckDB conn $
+        runInsert $
+          insertOnConflict
+            (_dbWidgets testDb)
+            (insertValues [Widget 2 "Sprocket-discount" 0.0])
+            (conflictingFields _widgetId)
+            ( onConflictUpdateSet
+                ( \fields _excluded ->
+                    _widgetPrice fields <-. current_ (_widgetPrice fields) - val_ 0.50
+                )
+            )
+      remaining <- queryAllWidgets conn
+      remaining
+        @?= [ Widget 1 "Widget" 9.99,
+              Widget 2 "Sprocket" 4.00,
+              Widget 3 "Cog" 1.25
+            ]
+
+testConflictingFieldsUpdateSetWhere :: TestTree
+testConflictingFieldsUpdateSetWhere =
+  testCase "conflictingFields + onConflictUpdateSetWhere only updates when predicate holds" $
+    withTestDb widgetData $ \conn -> do
+      runBeamDuckDB conn $
+        runInsert $
+          insertOnConflict
+            (_dbWidgets testDb)
+            ( insertValues
+                [ Widget 1 "Widget-replacement" 1.00,
+                  Widget 3 "Cog-replacement" 50.00
+                ]
+            )
+            (conflictingFields _widgetId)
+            ( onConflictUpdateSetWhere
+                ( \fields excludedRow ->
+                    _widgetName fields <-. _widgetName excludedRow
+                )
+                -- Only overwrite when the incoming price is higher than the existing one
+                ( \fields excludedRow ->
+                    _widgetPrice excludedRow >. current_ (_widgetPrice fields)
+                )
+            )
+      remaining <- queryAllWidgets conn
+      remaining
+        @?= [ Widget 1 "Widget" 9.99,
+              Widget 2 "Sprocket" 4.50,
+              Widget 3 "Cog-replacement" 1.25
+            ]
+
+testInsertOnConflictReturning :: TestTree
+testInsertOnConflictReturning =
+  testCase "INSERT ON CONFLICT ... RETURNING returns inserted-or-updated rows" $
+    withTestDb widgetData $ \conn -> do
+      returned <-
+        runBeamDuckDB conn $
+          runInsertReturningList $
+            insertOnConflict
+              (_dbWidgets testDb)
+              ( insertValues
+                  [ Widget 2 "Sprocket-v2" 6.00,
+                    Widget 4 "Gear" 7.75
+                  ]
+              )
+              (conflictingFields _widgetId)
+              onConflictUpdateAll
+      List.sort returned
+        @?= List.sort
+          [ Widget 2 "Sprocket-v2" 6.00,
+            Widget 4 "Gear" 7.75
+          ]
+
+data WidgetT f = Widget
+  { _widgetId :: Columnar f Int32,
+    _widgetName :: Columnar f Text,
+    _widgetPrice :: Columnar f Double
+  }
+  deriving (Generic)
+
+type Widget = WidgetT Identity
+
+deriving instance Show Widget
+
+deriving instance Eq Widget
+
+deriving instance Ord Widget
+
+instance Beamable WidgetT
+
+instance Table WidgetT where
+  data PrimaryKey WidgetT f = WidgetId (Columnar f Int32)
+    deriving (Generic)
+  primaryKey = WidgetId . _widgetId
+
+instance Beamable (PrimaryKey WidgetT)
+
+newtype TestDB f = TestDB
+  { _dbWidgets :: f (TableEntity WidgetT)
+  }
+  deriving (Generic, Database be)
+
+testDb :: DatabaseSettings DuckDB TestDB
+testDb =
+  defaultDbSettings
+    `withDbModification` dbModification
+      { _dbWidgets =
+          modifyTableFields
+            tableModification
+              { _widgetId = "id",
+                _widgetName = "name",
+                _widgetPrice = "price"
+              }
+      }
+
+createTables :: Connection -> IO ()
+createTables conn =
+  void $
+    execute_
+      conn
+      "CREATE TABLE widgets (\
+      \  id INTEGER PRIMARY KEY,\
+      \  name TEXT NOT NULL DEFAULT '',\
+      \  price DOUBLE NOT NULL DEFAULT 0\
+      \)"
+
+seedData :: Connection -> [Widget] -> IO ()
+seedData _ [] = pure ()
+seedData conn widgets =
+  void $
+    runBeamDuckDB conn $
+      runInsertReturningList $
+        insert (_dbWidgets testDb) (insertValues widgets)
+
+withTestDb :: [Widget] -> (Connection -> IO a) -> IO a
+withTestDb widgets action =
+  withConnection ":memory:" $ \conn -> do
+    createTables conn
+    seedData conn widgets
+    action conn
+
+queryAllWidgets :: Connection -> IO [Widget]
+queryAllWidgets conn =
+  runBeamDuckDB conn $
+    runSelectReturningList $
+      select $
+        orderBy_ (asc_ . _widgetId) $
+          all_ (_dbWidgets testDb)
+
+widgetData :: [Widget]
+widgetData =
+  [ Widget 1 "Widget" 9.99,
+    Widget 2 "Sprocket" 4.50,
+    Widget 3 "Cog" 1.25
+  ]

--- a/docs/user-guide/manipulation/insert.md
+++ b/docs/user-guide/manipulation/insert.md
@@ -276,7 +276,7 @@ insert it if not, you can use the `insertOnConflict` function with the `anyConfl
 
 !beam-query
 ```haskell
-!example chinookdml on:Sqlite on:Postgres
+!example chinookdml on:Sqlite on:Postgres on:DuckDB
 let
   newCustomer = Customer 42 "John" "Doe" Nothing (Address (Just "Street") (Just "City") (Just "State") Nothing Nothing) Nothing Nothing "john.doe@johndoe.com" nothing_
 
@@ -291,10 +291,9 @@ runInsert $
 Sometimes you only want to perform an action if a certain constraint is violated. If the conflicting
 index or constraint is on a field you can specify which fields with the function `conflictingFields`.
 
-<!-- The DuckDB backend doesn't yet support insertOnConflict  -->
 !beam-query
 ```haskell
-!example chinookdml !on:DuckDB
+!example chinookdml
 --! import Database.Beam.Backend.SQL.BeamExtensions (BeamHasInsertOnConflict(..))
 let
   newCustomer = Customer 42 "John" "Doe" Nothing (Address (Just "Street") (Just "City") (Just "State") Nothing Nothing) Nothing Nothing "john.doe@johndoe.com" nothing_
@@ -312,10 +311,9 @@ You can also specify how to change the record should it not match. For example, 
 as an alternate when you insert an existing row, you can use the `oldValues` argument to get access
 to the old value.
 
-<!-- The DuckDB backend doesn't yet support insertOnConflict  -->
 !beam-query
 ```haskell
-!example chinookdml !on:DuckDB
+!example chinookdml
 --! import Database.Beam.Backend.SQL.BeamExtensions (BeamHasInsertOnConflict(..))
 let
   newCustomer = Customer 42 "John" "Doe" Nothing (Address (Just "Street") (Just "City") (Just "State") Nothing Nothing) Nothing Nothing "john.doe@johndoe.com" nothing_
@@ -329,7 +327,12 @@ runInsert $
 If you want to be even more particular and only do this transformation on rows corresponding to
 customers from one state, use `conflictingFieldsWhere`.
 
-<!-- The DuckDB backend doesn't yet support insertOnConflict  -->
+!!! warning "Warning"
+    The DuckDB backend doesn't support `conflictingFieldsWhere`. If you try to import it from `Database.Beam.DuckDB`, you will get a type error.
+
+    However, since it's a required method of the `BeamHasInsertOnConflict` class, it's technically possible to import `conflictingFieldsWhere` from `Database.Beam.Backend.SQL.BeamExtensions`. Using this
+    version will result in a runtime error with the DuckDB backend.
+
 !beam-query
 ```haskell
 !example chinookdml !on:DuckDB


### PR DESCRIPTION
`BeamHasInsertOnConflict` instance for DuckDB.

Strangely, DuckDB does not support partial index matching in `ON CONFLICT ... WHERE`, which means that `conflictingFieldsWhere` isn't supported by DuckDB. Unfortunately, this is also one of the methods required by `BeamHasInsertOnConflict`.

To mitigate this problem, a shim `conflictingFieldsWhere` is provided by `beam-duckdb`, which results in a type error. The _real_ `conflictingFieldsWhere` is not re-exported by `beam-duckdb`.

However, if a user imports the real `conflictingFieldsWhere`, from `Database.Beam.Backend.SQL.BeamExtensions`, then a runtime error will be thrown. 

The long-term solution is to separate `conflictingFieldsWhere` in its own class, for which DuckDB wouldn't have an instance. This would be a breaking change in `beam-core` at least. Once this PR is merged, I'll create an issue. 