### PR TITLE
Support for the migration framework in beam-duckdb

### DIFF
--- a/beam-duckdb/CHANGELOG.md
+++ b/beam-duckdb/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.3.1.0 -- unreleased
 
+* Added support for `beam-migrate`: the new `Database.Beam.DuckDB.Migrate`
+  module exposes a `migrationBackend :: BeamMigrationBackend DuckDB DuckDBM`
+  value, along with other utilities. This brings DuckDB on par with `beam-postgres`
+  and `beam-sqlite` for schema verification and migration script generation.
 * Added file-mode `COPY ... TO 'file'` / `COPY ... FROM 'file'` support
   via the new `MonadBeamCopyTo` / `MonadBeamCopyFrom` instances on
   `DuckDBM`. Smart constructors `copyToCSV` / `copyToParquet` /

--- a/beam-duckdb/beam-duckdb.cabal
+++ b/beam-duckdb/beam-duckdb.cabal
@@ -36,9 +36,11 @@ common common
                  -Wredundant-constraints
                  -fhide-source-paths
                  -Wpartial-fields
+                 -Wunused-packages
 library
     import:           common
     exposed-modules:  Database.Beam.DuckDB
+                      Database.Beam.DuckDB.Migrate
     other-modules:    Database.Beam.DuckDB.Backend
                       Database.Beam.DuckDB.Connection
                       Database.Beam.DuckDB.Syntax
@@ -47,7 +49,8 @@ library
                       Database.Beam.DuckDB.Syntax.Extensions.Copy
                       Database.Beam.DuckDB.Syntax.Extensions.DataSource
                       Database.Beam.DuckDB.Syntax.Extensions.InsertOnConflict
-    build-depends:    base >=4.11 && <5
+    build-depends:    aeson >=1.0 && <2.3
+                    , base >=4.11 && <5
                     , beam-core >=0.11.1 && <0.12
                     , beam-migrate ^>=0.6
                     , bytestring >=0.10 && <0.13
@@ -56,6 +59,7 @@ library
                     , duckdb-simple (>=0.1.2 && <0.1.5) || (>=0.1.5.1 && <0.1.6)
                     , dlist >=0.8 && <1.1
                     , free >=4.12 && <5.3
+                    , hashable >=1.1 && <1.6
                     , scientific ^>=0.3
                     , text >=1.0 && <2.2
                     , time >=1.6 && <1.17
@@ -70,6 +74,7 @@ test-suite beam-duckdb-test
                       Database.Beam.DuckDB.Test.Extensions.DataSource
                       Database.Beam.DuckDB.Test.Extensions.InsertOnConflict
                       Database.Beam.DuckDB.Test.Extensions.Returning
+                      Database.Beam.DuckDB.Test.Migrate
                       Database.Beam.DuckDB.Test.Query
     type:             exitcode-stdio-1.0
     hs-source-dirs:   tests
@@ -77,6 +82,8 @@ test-suite beam-duckdb-test
     build-depends:    base >=4.11 && <5
                     , beam-core
                     , beam-duckdb
+                    , beam-migrate
+                    , bytestring
                     , duckdb-simple
                     , hedgehog
                     , tasty
@@ -85,3 +92,4 @@ test-suite beam-duckdb-test
                     , temporary
                     , text
                     , time
+                    , uuid-types

--- a/beam-duckdb/examples/ExamScores.hs
+++ b/beam-duckdb/examples/ExamScores.hs
@@ -2,19 +2,19 @@
 {- cabal:
   build-depends: base >= 4, beam-core, beam-duckdb, duckdb-simple, time, text
 -}
-
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE ExplicitForAll #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Main where
 
+import Data.Function
 import Data.Int
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.Text (Text)
@@ -22,18 +22,19 @@ import Data.Time
 import Database.Beam
 import Database.Beam.DuckDB
 import Database.DuckDB.Simple
-import Data.Function
 
 data ExamT f = Exam
   { _examId :: Columnar f Int32,
     _examName :: Columnar f Text,
     _examScore :: Columnar f Double,
     _examDate :: Columnar f Day
-  } deriving (Generic, Beamable)
+  }
+  deriving (Generic, Beamable)
 
 type Exam = ExamT Identity
 
 deriving instance Show (ExamT Identity)
+
 deriving instance Eq (ExamT Identity)
 
 instance Table ExamT where
@@ -42,7 +43,7 @@ instance Table ExamT where
   primaryKey = ExamKey <$> _examId
 
 data ScoresDB f = ScoresDB
-  { _scores :: f (DataSourceEntity ExamT) }
+  {_scores :: f (DataSourceEntity ExamT)}
   deriving (Generic)
 
 deriving instance Database DuckDB ScoresDB
@@ -63,11 +64,12 @@ scoresDb =
       }
 
 main = do
-  Just maxScore <- withConnection ":memory:"
-    $ \conn -> runBeamDuckDB conn
-      $ runSelectReturningOne
-        $ select
-          $ aggregate_
+  Just maxScore <- withConnection ":memory:" $
+    \conn ->
+      runBeamDuckDB conn $
+        runSelectReturningOne $
+          select $
+            aggregate_
               (max_ . _examScore)
               (allFromDataSource_ (_scores scoresDb))
 

--- a/beam-duckdb/src/Database/Beam/DuckDB/Backend.hs
+++ b/beam-duckdb/src/Database/Beam/DuckDB/Backend.hs
@@ -17,6 +17,7 @@ import Data.Functor (($>), (<&>))
 import Data.Int (Int16, Int32, Int64, Int8)
 import Data.Scientific (Scientific, scientific)
 import Data.Text (Text)
+import qualified Data.Text as Text
 import Data.Time (Day, LocalTime, TimeOfDay, UTCTime)
 import Data.UUID.Types (UUID)
 import Data.Word (Word16, Word32, Word64, Word8)
@@ -42,6 +43,7 @@ import Database.Beam.DuckDB.Syntax.Builder
     parens,
   )
 import Database.Beam.DuckDB.Syntax.Extensions.Copy (DuckDBCopyFromSyntax, DuckDBCopyToSyntax)
+import Database.Beam.Migrate.SQL (BeamMigrateOnlySqlBackend)
 import Database.Beam.Query.SQL92 (buildSql92Query')
 import Database.Beam.Query.Types (HasQBuilder (..))
 import Database.DuckDB.Simple (Null)
@@ -52,6 +54,8 @@ data DuckDB
 type instance BeamSqlBackendSyntax DuckDB = DuckDBCommandSyntax
 
 instance BeamSqlBackend DuckDB
+
+instance BeamMigrateOnlySqlBackend DuckDB
 
 type instance BeamSqlBackendCopyToSyntax DuckDB = DuckDBCopyToSyntax
 
@@ -108,6 +112,13 @@ instance FromBackendRow DuckDB Word32
 instance FromBackendRow DuckDB Word64
 
 instance FromBackendRow DuckDB Text
+
+instance FromBackendRow DuckDB Char where
+  fromBackendRow = do
+    t <- fromBackendRow @DuckDB @Text
+    case Text.uncons t of
+      Just (c, _) -> pure c
+      Nothing -> fail "Need string of size one to parse Char"
 
 instance FromBackendRow DuckDB ByteString
 

--- a/beam-duckdb/src/Database/Beam/DuckDB/Connection.hs
+++ b/beam-duckdb/src/Database/Beam/DuckDB/Connection.hs
@@ -16,6 +16,7 @@ module Database.Beam.DuckDB.Connection
     runBeamDuckDB,
     runBeamDuckDBDebug,
     runBeamDuckDBDebugString,
+    liftIOWithHandle,
     BeamDuckDBParams (..),
     BeamDuckDBRow (..),
   )
@@ -87,6 +88,12 @@ runBeamDuckDBDebug debug conn action =
 -- This is provided for compatibility with other backends
 runBeamDuckDBDebugString :: (String -> IO ()) -> Connection -> DuckDBM a -> IO a
 runBeamDuckDBDebugString debug = runBeamDuckDBDebug (debug . Text.unpack)
+
+-- | Run an IO action with access to the underlying DuckDB 'Connection'.
+-- This is mostly useful for migrate-backend implementors who need to issue
+-- raw queries against the connection.
+liftIOWithHandle :: (Connection -> IO a) -> DuckDBM a
+liftIOWithHandle f = DuckDBM $ ReaderT $ \(_, conn) -> f conn
 
 newtype BeamDuckDBParams = BeamDuckDBParams [SomeField]
 

--- a/beam-duckdb/src/Database/Beam/DuckDB/Migrate.hs
+++ b/beam-duckdb/src/Database/Beam/DuckDB/Migrate.hs
@@ -1,0 +1,621 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | Migrations support for @beam-duckdb@. See "Database.Beam.Migrate" for
+-- more information on beam migrations.
+module Database.Beam.DuckDB.Migrate
+  ( -- * Top-level @beam-migrate@ backend
+    migrationBackend,
+    DuckDBCommandSyntax,
+
+    -- * DuckDB-specific data types
+
+    --
+    -- DuckDB has a number of data types that aren't part of standard SQL or
+    -- that DuckDB names differently. These smart constructors produce
+    -- 'Db.DataType's tagged with @DuckDB@ so they can be used in
+    -- @beam-migrate@ schemas just like 'Database.Beam.Migrate.int' or
+    -- 'Database.Beam.Migrate.smallint'.
+    text,
+    blob,
+    tinyint,
+    uuid,
+    utinyint,
+    usmallint,
+    uinteger,
+    ubigint,
+
+    -- * Conversions and utilities
+    getDbConstraints,
+    getDbConstraintsForSchemas,
+    migrateScript,
+  )
+where
+
+import Control.Exception (SomeException (..), catch)
+import Control.Monad (forM, void)
+import Control.Monad.Trans.Reader (ReaderT (..))
+import Data.Aeson (object, withText, (.=))
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Lazy as BL
+import Data.Char (isDigit)
+import Data.Int (Int8)
+import qualified Data.List.NonEmpty as NE
+import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Monoid (Endo (..))
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import Data.UUID.Types (UUID)
+import Data.Word (Word16, Word32, Word64, Word8)
+import Database.Beam.Backend.SQL
+import Database.Beam.DuckDB.Backend (DuckDB)
+import Database.Beam.DuckDB.Connection
+  ( DuckDBM (..),
+    liftIOWithHandle,
+  )
+import Database.Beam.DuckDB.Syntax
+  ( DuckDBCommandSyntax (..),
+    DuckDBDataTypeSyntax (..),
+  )
+import Database.Beam.DuckDB.Syntax.Builder
+  ( duckDBRenderSyntaxScript,
+    emit,
+  )
+import Database.Beam.Haskell.Syntax
+import Database.Beam.Migrate.Actions
+  ( createIndexActionProvider,
+    defaultActionProvider,
+    defaultSchemaActionProvider,
+    dropIndexActionProvider,
+  )
+import qualified Database.Beam.Migrate.Backend as Tool
+import qualified Database.Beam.Migrate.Checks as Db
+import qualified Database.Beam.Migrate.SQL as Db
+import qualified Database.Beam.Migrate.Serialization as Db
+import qualified Database.Beam.Migrate.Types as Db
+import qualified Database.Beam.Query.DataTypes as Db
+import qualified Database.DuckDB.Simple as DuckDB
+import Database.DuckDB.Simple.Types (Only (..))
+
+-- | Top-level migration backend for use by @beam-migrate@ tools.
+--
+-- @since 0.3.1.0
+migrationBackend :: Tool.BeamMigrationBackend DuckDB DuckDBM
+migrationBackend =
+  Tool.BeamMigrationBackend
+    { Tool.backendName = "duckdb",
+      Tool.backendConnStringExplanation =
+        unlines
+          [ "For beam-duckdb, this is the path to a DuckDB database file, or :memory: for an in-memory database.",
+            "",
+            "See <https://duckdb.org/docs/connect.html> for more information."
+          ],
+      Tool.backendGetDbConstraints = getDbConstraints,
+      Tool.backendPredicateParsers =
+        Db.sql92Deserializers
+          <> Db.sql99DataTypeDeserializers
+          <> Db.sql2008BigIntDataTypeDeserializers
+          <> duckDBDataTypeDeserializers
+          <> Db.beamCheckDeserializers,
+      Tool.backendRenderSyntax = renderDuckDBCommand,
+      Tool.backendFileExtension = "duckdb.sql",
+      Tool.backendConvertToHaskell = duckDBPredConverter,
+      Tool.backendActionProvider =
+        mconcat
+          [ defaultActionProvider,
+            defaultSchemaActionProvider,
+            createIndexActionProvider,
+            dropIndexActionProvider
+          ],
+      Tool.backendRunSqlScript = \t -> liftIOWithHandle $ \conn ->
+        void $ DuckDB.execute_ conn (DuckDB.Query t),
+      Tool.backendWithTransaction = duckDBMWithTransaction,
+      Tool.backendConnect = \options -> do
+        conn <- DuckDB.open options
+        pure
+          Tool.BeamMigrateConnection
+            { Tool.backendRun = \(DuckDBM action) ->
+                catch
+                  (Right <$> runReaderT action (\_ -> pure (), conn))
+                  (\e -> pure (Left (show (e :: SomeException)))),
+              Tool.backendClose = DuckDB.close conn
+            }
+    }
+  where
+    duckDBMWithTransaction :: forall a. DuckDBM a -> DuckDBM a
+    duckDBMWithTransaction (DuckDBM (ReaderT k)) =
+      DuckDBM $ ReaderT $ \ctx@(_, conn) ->
+        DuckDB.withTransaction conn (k ctx)
+
+    renderDuckDBCommand :: DuckDBCommandSyntax -> String
+    renderDuckDBCommand (DuckDBCommandSyntax inner) =
+      T.unpack (duckDBRenderSyntaxScript inner) ++ ";"
+
+    duckDBPredConverter :: Tool.HaskellPredicateConverter
+    duckDBPredConverter =
+      Tool.sql92HsPredicateConverters @DuckDB duckDBTypeToHs
+        <> Tool.hsPredicateConverter duckDBHasColumnConstraint
+      where
+        duckDBHasColumnConstraint
+          ( Db.TableColumnHasConstraint tblNm colNm c ::
+              Db.TableColumnHasConstraint DuckDB
+            )
+            | c == Db.constraintDefinitionSyntax Nothing Db.notNullConstraintSyntax Nothing =
+                Just
+                  ( Db.SomeDatabasePredicate
+                      ( Db.TableColumnHasConstraint
+                          tblNm
+                          colNm
+                          (Db.constraintDefinitionSyntax Nothing Db.notNullConstraintSyntax Nothing) ::
+                          Db.TableColumnHasConstraint HsMigrateBackend
+                      )
+                  )
+            | otherwise = Nothing
+
+        duckDBTypeToHs :: DuckDBDataTypeSyntax -> Maybe HsDataType
+        duckDBTypeToHs = Just . hsErrorType . T.unpack . duckDBRenderSyntaxScript . duckDBDataType
+
+-- | Build a backend-specific 'Db.BeamSerializedDataType' for DuckDB, tagged
+-- with the given keyword. Used to give DuckDB-only types a stable serialized
+-- representation that round-trips through @beam-migrate@'s predicate cache.
+duckDBDataTypeJSON :: Text -> Db.BeamSerializedDataType
+duckDBDataTypeJSON tag =
+  Db.BeamSerializedDataType (Db.beamSerializeJSON "duckdb" (object ["data-type" .= tag]))
+
+duckDBTinyIntType :: DuckDBDataTypeSyntax
+duckDBTinyIntType = DuckDBDataTypeSyntax (emit "TINYINT") (duckDBDataTypeJSON "tinyint")
+
+duckDBHugeIntType :: DuckDBDataTypeSyntax
+duckDBHugeIntType = DuckDBDataTypeSyntax (emit "HUGEINT") (duckDBDataTypeJSON "hugeint")
+
+duckDBUuidType :: DuckDBDataTypeSyntax
+duckDBUuidType = DuckDBDataTypeSyntax (emit "UUID") (duckDBDataTypeJSON "uuid")
+
+duckDBUTinyIntType :: DuckDBDataTypeSyntax
+duckDBUTinyIntType = DuckDBDataTypeSyntax (emit "UTINYINT") (duckDBDataTypeJSON "utinyint")
+
+duckDBUSmallIntType :: DuckDBDataTypeSyntax
+duckDBUSmallIntType = DuckDBDataTypeSyntax (emit "USMALLINT") (duckDBDataTypeJSON "usmallint")
+
+duckDBUIntegerType :: DuckDBDataTypeSyntax
+duckDBUIntegerType = DuckDBDataTypeSyntax (emit "UINTEGER") (duckDBDataTypeJSON "uinteger")
+
+duckDBUBigIntType :: DuckDBDataTypeSyntax
+duckDBUBigIntType = DuckDBDataTypeSyntax (emit "UBIGINT") (duckDBDataTypeJSON "ubigint")
+
+duckDBUHugeIntType :: DuckDBDataTypeSyntax
+duckDBUHugeIntType = DuckDBDataTypeSyntax (emit "UHUGEINT") (duckDBDataTypeJSON "uhugeint")
+
+-- | DuckDB @TEXT@. Equivalent to 'Database.Beam.Migrate.characterLargeObject'
+-- and to @VARCHAR@ without a length limit; DuckDB reports all three as
+-- @VARCHAR@ in @information_schema@.
+--
+-- @since 0.3.1.0
+text :: Db.DataType DuckDB Text
+text = Db.DataType (varCharType Nothing Nothing)
+
+-- | DuckDB @BLOB@ for arbitrary binary data. Equivalent to
+-- 'Database.Beam.Migrate.binaryLargeObject' (DuckDB accepts both @BLOB@ and
+-- @BYTEA@ in DDL but reports @BLOB@ in @information_schema@).
+--
+-- @since 0.3.1.0
+blob :: Db.DataType DuckDB ByteString
+blob = Db.DataType binaryLargeObjectType
+
+-- | DuckDB @TINYINT@ — a signed 8-bit integer. Not part of SQL standard
+-- nor of beam-core (which only exposes 'smallint' upwards).
+--
+-- @since 0.3.1.0
+tinyint :: Db.DataType DuckDB Int8
+tinyint = Db.DataType duckDBTinyIntType
+
+-- | DuckDB @UUID@. Maps to 'Data.UUID.Types.UUID' from @uuid-types@.
+--
+-- @since 0.3.1.0
+uuid :: Db.DataType DuckDB UUID
+uuid = Db.DataType duckDBUuidType
+
+-- | DuckDB @UTINYINT@ — an unsigned 8-bit integer.
+--
+-- @since 0.3.1.0
+utinyint :: Db.DataType DuckDB Word8
+utinyint = Db.DataType duckDBUTinyIntType
+
+-- | DuckDB @USMALLINT@ — an unsigned 16-bit integer.
+--
+-- @since 0.3.1.0
+usmallint :: Db.DataType DuckDB Word16
+usmallint = Db.DataType duckDBUSmallIntType
+
+-- | DuckDB @UINTEGER@ — an unsigned 32-bit integer.
+--
+-- @since 0.3.1.0
+uinteger :: Db.DataType DuckDB Word32
+uinteger = Db.DataType duckDBUIntegerType
+
+-- | DuckDB @UBIGINT@ — an unsigned 64-bit integer.
+--
+-- @since 0.3.1.0
+ubigint :: Db.DataType DuckDB Word64
+ubigint = Db.DataType duckDBUBigIntType
+
+-- | 'Db.BeamDeserializers' for DuckDB-specific data types not covered by
+-- the standard SQL92/SQL99/SQL2008 deserializers. Wired into
+-- 'migrationBackend' by default.
+--
+-- @since 0.3.1.0
+duckDBDataTypeDeserializers :: Db.BeamDeserializers DuckDB
+duckDBDataTypeDeserializers =
+  Db.beamDeserializer $ \_ ->
+    withText "DuckDB data type" $ \tag ->
+      case tag of
+        "tinyint" -> pure duckDBTinyIntType
+        "hugeint" -> pure duckDBHugeIntType
+        "uuid" -> pure duckDBUuidType
+        "utinyint" -> pure duckDBUTinyIntType
+        "usmallint" -> pure duckDBUSmallIntType
+        "uinteger" -> pure duckDBUIntegerType
+        "ubigint" -> pure duckDBUBigIntType
+        "uhugeint" -> pure duckDBUHugeIntType
+        _ -> fail $ "Unknown DuckDB data type with tag " <> T.unpack tag
+
+-- | Render a series of 'Db.MigrationSteps' for DuckDB as a list of lazy
+-- 'BL.ByteString's suitable for assembling a migration script.
+--
+-- @since 0.3.1.0
+migrateScript :: Db.MigrationSteps DuckDB () a -> [BL.ByteString]
+migrateScript steps =
+  "-- Generated by beam-duckdb beam-migrate backend\n"
+    : "\n"
+    : appEndo (Db.migrateScript renderHeader renderCommand steps) []
+  where
+    renderHeader nm =
+      Endo (("-- " <> BL.fromStrict (TE.encodeUtf8 nm) <> "\n") :)
+    renderCommand (DuckDBCommandSyntax inner) =
+      Endo ((BL.fromStrict (TE.encodeUtf8 (duckDBRenderSyntaxScript inner)) <> ";\n") :)
+
+-- | Convert a DuckDB type name (as reported by @information_schema@) into a
+-- 'DuckDBDataTypeSyntax', or 'Nothing' if the name is not recognised.
+--
+-- Handles common DuckDB-printed forms such as @INTEGER@, @VARCHAR(10)@,
+-- @DECIMAL(18,3)@, @TIMESTAMP WITH TIME ZONE@, etc.
+duckDBDataTypeFromText :: Text -> Maybe DuckDBDataTypeSyntax
+duckDBDataTypeFromText t0 =
+  let t = T.toUpper (T.strip t0)
+      (base, parens) = splitParens t
+   in case base of
+        "BOOLEAN" -> Just booleanType
+        "BOOL" -> Just booleanType
+        "TINYINT" -> Just duckDBTinyIntType
+        "INT1" -> Just duckDBTinyIntType
+        "SMALLINT" -> Just smallIntType
+        "INT2" -> Just smallIntType
+        "INTEGER" -> Just intType
+        "INT" -> Just intType
+        "INT4" -> Just intType
+        "BIGINT" -> Just bigIntType
+        "INT8" -> Just bigIntType
+        "HUGEINT" -> Just duckDBHugeIntType
+        "UTINYINT" -> Just duckDBUTinyIntType
+        "USMALLINT" -> Just duckDBUSmallIntType
+        "UINTEGER" -> Just duckDBUIntegerType
+        "UBIGINT" -> Just duckDBUBigIntType
+        "UHUGEINT" -> Just duckDBUHugeIntType
+        "REAL" -> Just realType
+        "FLOAT" -> Just (floatType (parsePrec parens))
+        "FLOAT4" -> Just realType
+        "DOUBLE" -> Just doubleType
+        "FLOAT8" -> Just doubleType
+        "DOUBLE PRECISION" -> Just doubleType
+        "NUMERIC" -> Just (numericType (parseNumericPrec parens))
+        "DECIMAL" -> Just (decimalType (parseNumericPrec parens))
+        "VARCHAR" -> Just (varCharType (parsePrec parens) Nothing)
+        "CHAR" -> Just (charType (parsePrec parens) Nothing)
+        "CHARACTER" -> Just (charType (parsePrec parens) Nothing)
+        "CHARACTER VARYING" -> Just (varCharType (parsePrec parens) Nothing)
+        "TEXT" -> Just (varCharType Nothing Nothing)
+        "STRING" -> Just (varCharType Nothing Nothing)
+        "BLOB" -> Just binaryLargeObjectType
+        "BYTEA" -> Just binaryLargeObjectType
+        "UUID" -> Just duckDBUuidType
+        "DATE" -> Just dateType
+        "TIME" -> Just (timeType (parsePrec parens) False)
+        "TIME WITH TIME ZONE" -> Just (timeType (parsePrec parens) True)
+        "TIMETZ" -> Just (timeType (parsePrec parens) True)
+        "TIMESTAMP" -> Just (timestampType (parsePrec parens) False)
+        "TIMESTAMP WITH TIME ZONE" -> Just (timestampType (parsePrec parens) True)
+        "TIMESTAMPTZ" -> Just (timestampType (parsePrec parens) True)
+        _ -> Nothing
+  where
+    splitParens :: Text -> (Text, Maybe Text)
+    splitParens t =
+      case T.breakOn "(" t of
+        (base, "") -> (T.strip base, Nothing)
+        (base, rest) ->
+          let inside = T.dropWhile (== '(') (T.dropWhileEnd (== ')') rest)
+           in (T.strip base, Just (T.strip inside))
+
+    parsePrec :: Maybe Text -> Maybe Word
+    parsePrec Nothing = Nothing
+    parsePrec (Just t)
+      | T.null digits = Nothing
+      | otherwise = Just (read (T.unpack digits))
+      where
+        digits = T.takeWhile isDigit (T.strip t)
+
+    parseNumericPrec :: Maybe Text -> Maybe (Word, Maybe Word)
+    parseNumericPrec Nothing = Nothing
+    parseNumericPrec (Just t) =
+      case T.splitOn "," t of
+        [p] -> fmap (,Nothing) (readMaybeWord (T.strip p))
+        [p, d] -> case (readMaybeWord (T.strip p), readMaybeWord (T.strip d)) of
+          (Just pw, Just dw) -> Just (pw, Just dw)
+          (Just pw, Nothing) -> Just (pw, Nothing)
+          _ -> Nothing
+        _ -> Nothing
+
+    readMaybeWord :: Text -> Maybe Word
+    readMaybeWord t
+      | T.null t || T.any (not . isDigit) t = Nothing
+      | otherwise = Just (read (T.unpack t))
+
+-- | Discover the set of 'Db.SomeDatabasePredicate's describing the current
+-- DuckDB database. Includes schema, table, column, primary-key, secondary
+-- index, and foreign-key constraint predicates.
+--
+-- @since 0.3.1.0
+getDbConstraints :: DuckDBM [Db.SomeDatabasePredicate]
+getDbConstraints = do
+  schemas <-
+    liftIOWithHandle $ \conn ->
+      DuckDB.query_
+        conn
+        "SELECT schema_name FROM information_schema.schemata \
+        \WHERE schema_name NOT IN ('information_schema', 'pg_catalog', 'main') \
+        \AND schema_name NOT LIKE 'pg\\_%' ESCAPE '\\'"
+  let userSchemas = map (\(Only s) -> s) schemas :: [Text]
+  case userSchemas of
+    [] -> getDbConstraintsForSchemas Nothing
+    ss ->
+      (++)
+        <$> getDbConstraintsForSchemas (Just ss)
+        <*> getDbConstraintsForSchemas Nothing
+
+-- | Like 'getDbConstraints', but optionally restricted to a list of schemas.
+-- If 'Nothing', the @main@ schema (the DuckDB default) is queried.
+--
+-- @since 0.3.1.0
+getDbConstraintsForSchemas :: Maybe [Text] -> DuckDBM [Db.SomeDatabasePredicate]
+getDbConstraintsForSchemas mSchemas = do
+  let schemaFilter = case mSchemas of
+        Nothing -> "table_schema = '" <> implicitSchema <> "'"
+        Just ss ->
+          "table_schema IN ("
+            <> T.intercalate
+              ","
+              (map (\s -> "'" <> s <> "'") ss)
+            <> ")"
+      schemaPreds =
+        case mSchemas of
+          Nothing -> []
+          Just ss -> map (Db.SomeDatabasePredicate . Db.SchemaExistsPredicate) ss
+
+  tbls <-
+    liftIOWithHandle $ \conn ->
+      DuckDB.query_ conn $
+        DuckDB.Query $
+          T.unlines
+            [ "SELECT table_schema, table_name FROM information_schema.tables",
+              "WHERE table_type='BASE TABLE' AND " <> schemaFilter
+            ]
+  let tblExistsPreds =
+        map
+          ( \(s, t) ->
+              Db.SomeDatabasePredicate
+                ( Db.TableExistsPredicate
+                    (Db.QualifiedName (qualifySchema s mSchemas) t)
+                )
+          )
+          tbls
+
+  columnsAndConstraints <-
+    fmap mconcat . forM tbls $ \(s, t) -> collectColumnInfo s t mSchemas
+
+  primaryKeyPreds <- collectPrimaryKeys schemaFilter mSchemas
+  fkPreds <- collectForeignKeys schemaFilter mSchemas
+
+  pure $
+    concat
+      [ schemaPreds,
+        tblExistsPreds,
+        columnsAndConstraints,
+        primaryKeyPreds,
+        fkPreds
+      ]
+
+-- | The implicit schema in case it's not specified
+--
+-- https://duckdb.org/docs/lts/sql/statements/use
+implicitSchema :: Text
+implicitSchema = "main"
+
+-- | If we are looking at the 'main' schema, qualify columns/tables with
+-- 'Nothing' (the implicit default). Otherwise qualify with the actual schema.
+qualifySchema :: Text -> Maybe [Text] -> Maybe Text
+qualifySchema s Nothing
+  | s == implicitSchema = Nothing
+  | otherwise = Just s
+qualifySchema s _ = Just s
+
+collectColumnInfo ::
+  Text ->
+  Text ->
+  Maybe [Text] ->
+  DuckDBM [Db.SomeDatabasePredicate]
+collectColumnInfo schemaNm tblNm mSchemas = do
+  columns <-
+    liftIOWithHandle $ \conn ->
+      DuckDB.query
+        conn
+        "SELECT column_name, data_type, is_nullable \
+        \FROM information_schema.columns \
+        \WHERE table_schema = ? AND table_name = ? \
+        \ORDER BY ordinal_position"
+        (schemaNm, tblNm)
+  let qual = Db.QualifiedName (qualifySchema schemaNm mSchemas) tblNm
+      mkPreds (colNm, typ, isNullable) =
+        let dt = fromMaybe (unknownDuckDBType typ) (duckDBDataTypeFromText typ)
+            colPred =
+              Db.SomeDatabasePredicate
+                ( Db.TableHasColumn qual colNm dt ::
+                    Db.TableHasColumn DuckDB
+                )
+            notNullPred =
+              ( [ Db.SomeDatabasePredicate
+                    ( Db.TableColumnHasConstraint
+                        qual
+                        colNm
+                        ( Db.constraintDefinitionSyntax
+                            Nothing
+                            Db.notNullConstraintSyntax
+                            Nothing
+                        ) ::
+                        Db.TableColumnHasConstraint DuckDB
+                    )
+                | isNullable == ("NO" :: Text)
+                ]
+              )
+         in colPred : notNullPred
+  pure $ concatMap mkPreds (columns :: [(Text, Text, Text)])
+  where
+    unknownDuckDBType :: Text -> DuckDBDataTypeSyntax
+    unknownDuckDBType = domainType
+
+collectPrimaryKeys ::
+  Text ->
+  Maybe [Text] ->
+  DuckDBM [Db.SomeDatabasePredicate]
+collectPrimaryKeys schemaFilter mSchemas = do
+  rows <-
+    liftIOWithHandle $ \conn ->
+      DuckDB.query_ conn $
+        DuckDB.Query $
+          T.unlines
+            [ "SELECT tc.table_schema, tc.table_name, kcu.column_name, kcu.ordinal_position",
+              "FROM information_schema.table_constraints tc",
+              "JOIN information_schema.key_column_usage kcu",
+              "  ON tc.constraint_name = kcu.constraint_name",
+              " AND tc.constraint_schema = kcu.constraint_schema",
+              " AND tc.table_name = kcu.table_name",
+              "WHERE tc.constraint_type = 'PRIMARY KEY' AND tc." <> schemaFilter,
+              "ORDER BY tc.table_schema, tc.table_name, kcu.ordinal_position"
+            ]
+  let grouped = groupByPk (rows :: [(Text, Text, Text, Int)])
+  pure $
+    map
+      ( \((sch, tbl), cols) ->
+          Db.SomeDatabasePredicate
+            ( Db.TableHasPrimaryKey
+                (Db.QualifiedName (qualifySchema sch mSchemas) tbl)
+                cols
+            )
+      )
+      grouped
+
+groupByPk ::
+  [(Text, Text, Text, Int)] ->
+  [((Text, Text), [Text])]
+groupByPk = go []
+  where
+    go acc [] = reverse acc
+    go acc rs@((s, t, _, _) : _) =
+      let (here, rest) = span (\(s', t', _, _) -> s == s' && t == t') rs
+          cols = map (\(_, _, c, _) -> c) here
+       in go (((s, t), cols) : acc) rest
+
+collectForeignKeys ::
+  Text ->
+  Maybe [Text] ->
+  DuckDBM [Db.SomeDatabasePredicate]
+collectForeignKeys schemaFilter mSchemas = do
+  rows <-
+    liftIOWithHandle $ \conn ->
+      DuckDB.query_ conn $
+        DuckDB.Query $
+          T.unlines
+            [ "SELECT tc.table_schema, tc.table_name, kcu.column_name,",
+              "       ccu.table_schema, ccu.table_name, ccu.column_name,",
+              "       rc.update_rule, rc.delete_rule,",
+              "       kcu.ordinal_position",
+              "FROM information_schema.table_constraints tc",
+              "JOIN information_schema.key_column_usage kcu",
+              "  ON tc.constraint_name = kcu.constraint_name",
+              " AND tc.constraint_schema = kcu.constraint_schema",
+              "JOIN information_schema.referential_constraints rc",
+              "  ON rc.constraint_name = tc.constraint_name",
+              " AND rc.constraint_schema = tc.constraint_schema",
+              "JOIN information_schema.constraint_column_usage ccu",
+              "  ON ccu.constraint_name = rc.unique_constraint_name",
+              " AND ccu.constraint_schema = rc.unique_constraint_schema",
+              "WHERE tc.constraint_type = 'FOREIGN KEY' AND tc." <> schemaFilter,
+              "ORDER BY tc.constraint_schema, tc.constraint_name, kcu.ordinal_position"
+            ]
+  pure $
+    mapMaybe mkFk $
+      groupByFk
+        ( rows ::
+            [ ( Text,
+                Text,
+                Text,
+                Text,
+                Text,
+                Text,
+                Text,
+                Text,
+                Int
+              )
+            ]
+        )
+  where
+    groupByFk = go []
+      where
+        go acc [] = reverse acc
+        go acc rs@((s, t, _, fs, ft, _, _, _, _) : _) =
+          let (here, rest) =
+                span
+                  ( \(s', t', _, fs', ft', _, _, _, _) ->
+                      s == s' && t == t' && fs == fs' && ft == ft'
+                  )
+                  rs
+           in go (here : acc) rest
+
+    mkFk [] = Nothing
+    mkFk rows@((srcSchema, srcTbl, _, refSchema, refTbl, _, upd, del, _) : _) =
+      let localCols = map (\(_, _, c, _, _, _, _, _, _) -> c) rows
+          refCols = map (\(_, _, _, _, _, c, _, _, _) -> c) rows
+       in case (NE.nonEmpty localCols, NE.nonEmpty refCols) of
+            (Just lc, Just rc) ->
+              Just $
+                Db.SomeDatabasePredicate
+                  ( Db.TableHasForeignKey
+                      (Db.QualifiedName (qualifySchema srcSchema mSchemas) srcTbl)
+                      lc
+                      (Db.QualifiedName (qualifySchema refSchema mSchemas) refTbl)
+                      rc
+                      (parseDuckDBForeignKeyAction upd)
+                      (parseDuckDBForeignKeyAction del)
+                  )
+            _ -> Nothing
+
+    parseDuckDBForeignKeyAction :: Text -> Db.ForeignKeyAction
+    parseDuckDBForeignKeyAction t =
+      case T.toUpper t of
+        "CASCADE" -> Db.ForeignKeyActionCascade
+        "SET NULL" -> Db.ForeignKeyActionSetNull
+        "SET DEFAULT" -> Db.ForeignKeyActionSetDefault
+        "RESTRICT" -> Db.ForeignKeyActionRestrict
+        "NO ACTION" -> Db.ForeignKeyNoAction
+        _ -> Db.ForeignKeyNoAction

--- a/beam-duckdb/src/Database/Beam/DuckDB/Syntax.hs
+++ b/beam-duckdb/src/Database/Beam/DuckDB/Syntax.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -20,12 +21,34 @@ module Database.Beam.DuckDB.Syntax
     DuckDBTableNameSyntax (..),
     DuckDBOnConflictSyntax (..),
     DuckDBFieldNameSyntax (..),
+
+    -- * DDL syntaxes
+    DuckDBDataTypeSyntax (..),
+    DuckDBCreateTableSyntax (..),
+    DuckDBDropTableSyntax (..),
+    DuckDBAlterTableSyntax (..),
+    DuckDBAlterTableActionSyntax (..),
+    DuckDBAlterColumnActionSyntax (..),
+    DuckDBCreateSchemaSyntax (..),
+    DuckDBDropSchemaSyntax (..),
+    DuckDBSchemaNameSyntax (..),
+    DuckDBColumnSchemaSyntax (..),
+    DuckDBColumnConstraintDefinitionSyntax (..),
+    DuckDBColumnConstraintSyntax (..),
+    DuckDBTableConstraintSyntax (..),
+    DuckDBMatchTypeSyntax (..),
+    DuckDBReferentialActionSyntax (..),
+    DuckDBTableOptionsSyntax (..),
+    DuckDBIndexOptions (..),
   )
 where
 
+import Data.Aeson (object, withObject, (.:), (.=))
 import Data.Bifunctor (second)
 import Data.Coerce (coerce)
+import Data.Hashable (Hashable (..))
 import Data.Int (Int16, Int32, Int64, Int8)
+import qualified Data.List.NonEmpty as NE
 import Data.Scientific (Scientific)
 import Data.String (fromString)
 import Data.Text (Text)
@@ -63,6 +86,7 @@ import Database.Beam.Backend
     IsSql92OrderingSyntax (..),
     IsSql92ProjectionSyntax (..),
     IsSql92QuantifierSyntax (..),
+    IsSql92SchemaNameSyntax (..),
     IsSql92SelectSyntax (..),
     IsSql92SelectTableSyntax (..),
     IsSql92Syntax (..),
@@ -79,8 +103,46 @@ import Database.Beam.Backend
     IsSql99RecursiveCommonTableExpressionSelectSyntax (..),
     SqlNull (..),
   )
-import Database.Beam.DuckDB.Syntax.Builder (DuckDBSyntax, commas, emit, emitChar, emitIntegral, emitRealFloat, emitScientific, emitValue, parens, quotedIdentifier, sepBy, spaces)
-import Database.Beam.Migrate.Serialization (BeamSerializedDataType)
+import Database.Beam.Backend.SQL
+  ( IsSql2003BinaryAndVarBinaryDataTypeSyntax (..),
+    IsSql2008BigIntDataTypeSyntax (..),
+    Sql92DisplaySyntax (..),
+  )
+import Database.Beam.DuckDB.Syntax.Builder (DuckDBSyntax, commas, duckDBRenderSyntaxScript, emit, emitChar, emitIntegral, emitRealFloat, emitScientific, emitValue, parens, quotedIdentifier, sepBy, spaces)
+import Database.Beam.Migrate.Checks (HasDataTypeCreatedCheck (..))
+import Database.Beam.Migrate.SQL
+  ( IsSql92AlterColumnActionSyntax (..),
+    IsSql92AlterTableActionSyntax (..),
+    IsSql92AlterTableSyntax (..),
+    IsSql92ColumnConstraintDefinitionSyntax (..),
+    IsSql92ColumnConstraintSyntax (..),
+    IsSql92ColumnSchemaSyntax (..),
+    IsSql92CreateDropIndexSyntax (..),
+    IsSql92CreateSchemaSyntax (..),
+    IsSql92CreateTableSyntax (..),
+    IsSql92DdlCommandSyntax (..),
+    IsSql92DdlSchemaCommandSyntax (..),
+    IsSql92DropSchemaSyntax (..),
+    IsSql92DropTableSyntax (..),
+    IsSql92MatchTypeSyntax (..),
+    IsSql92ReferentialActionSyntax (..),
+    IsSql92TableConstraintSyntax (..),
+    IsSql92UniqueIndexSyntax (..),
+    Sql92SerializableConstraintDefinitionSyntax (..),
+    Sql92SerializableDataTypeSyntax (..),
+  )
+import Database.Beam.Migrate.SQL.Builder (ConstraintAttributeTiming (..), SqlConstraintAttributesBuilder (..), sqlConstraintAttributesSerialized)
+import Database.Beam.Migrate.SQL.SQL92 (ForeignKeyAction (..))
+import Database.Beam.Migrate.Serialization
+  ( BeamSerializedConstraint,
+    BeamSerializedConstraintDefinition,
+    BeamSerializedDataType (..),
+    BeamSerializedExpression (..),
+    BeamSerializedMatchType,
+    BeamSerializedReferentialAction,
+    fromBeamSerializedConstraintDefinition,
+    fromBeamSerializedDataType,
+  )
 import Database.DuckDB.Simple (Null (Null))
 
 newtype DuckDBCommandSyntax = DuckDBCommandSyntax {fromDuckDBSyntax :: DuckDBSyntax}
@@ -96,6 +158,22 @@ instance IsSql92Syntax DuckDBCommandSyntax where
   insertCmd = DuckDBCommandSyntax . fromDuckDBInsert
   updateCmd = DuckDBCommandSyntax . fromDuckDBUpdate
   deleteCmd = DuckDBCommandSyntax . fromDuckDBDelete
+
+instance IsSql92DdlCommandSyntax DuckDBCommandSyntax where
+  type Sql92DdlCommandCreateTableSyntax DuckDBCommandSyntax = DuckDBCreateTableSyntax
+  type Sql92DdlCommandDropTableSyntax DuckDBCommandSyntax = DuckDBDropTableSyntax
+  type Sql92DdlCommandAlterTableSyntax DuckDBCommandSyntax = DuckDBAlterTableSyntax
+
+  createTableCmd = DuckDBCommandSyntax . fromDuckDBCreateTable
+  dropTableCmd = DuckDBCommandSyntax . fromDuckDBDropTable
+  alterTableCmd = DuckDBCommandSyntax . fromDuckDBAlterTable
+
+instance IsSql92DdlSchemaCommandSyntax DuckDBCommandSyntax where
+  type Sql92DdlCommandCreateSchemaSyntax DuckDBCommandSyntax = DuckDBCreateSchemaSyntax
+  type Sql92DdlCommandDropSchemaSyntax DuckDBCommandSyntax = DuckDBDropSchemaSyntax
+
+  createSchemaCmd = DuckDBCommandSyntax . fromDuckDBCreateSchema
+  dropSchemaCmd = DuckDBCommandSyntax . fromDuckDBDropSchema
 
 newtype DuckDBTableNameSyntax = DuckDBTableNameSyntax {fromDuckDBTableName :: DuckDBSyntax}
 
@@ -124,6 +202,57 @@ data DuckDBDataTypeSyntax = DuckDBDataTypeSyntax
   { duckDBDataType :: DuckDBSyntax,
     duckDBDataTypeSerialized :: BeamSerializedDataType
   }
+  deriving (Show)
+
+-- DDL syntax newtypes used by 'IsSql92DdlCommandSyntax' and friends.
+
+newtype DuckDBCreateTableSyntax = DuckDBCreateTableSyntax {fromDuckDBCreateTable :: DuckDBSyntax}
+
+data DuckDBTableOptionsSyntax = DuckDBTableOptionsSyntax DuckDBSyntax DuckDBSyntax
+
+newtype DuckDBDropTableSyntax = DuckDBDropTableSyntax {fromDuckDBDropTable :: DuckDBSyntax}
+
+newtype DuckDBAlterTableSyntax = DuckDBAlterTableSyntax {fromDuckDBAlterTable :: DuckDBSyntax}
+
+newtype DuckDBAlterTableActionSyntax = DuckDBAlterTableActionSyntax {fromDuckDBAlterTableAction :: DuckDBSyntax}
+
+newtype DuckDBAlterColumnActionSyntax = DuckDBAlterColumnActionSyntax {fromDuckDBAlterColumnAction :: DuckDBSyntax}
+
+newtype DuckDBCreateSchemaSyntax = DuckDBCreateSchemaSyntax {fromDuckDBCreateSchema :: DuckDBSyntax}
+
+newtype DuckDBDropSchemaSyntax = DuckDBDropSchemaSyntax {fromDuckDBDropSchema :: DuckDBSyntax}
+
+newtype DuckDBSchemaNameSyntax = DuckDBSchemaNameSyntax {fromDuckDBSchemaName :: DuckDBSyntax}
+
+newtype DuckDBColumnSchemaSyntax = DuckDBColumnSchemaSyntax {fromDuckDBColumnSchema :: DuckDBSyntax}
+  deriving (Show, Eq)
+
+data DuckDBColumnConstraintDefinitionSyntax = DuckDBColumnConstraintDefinitionSyntax
+  { fromDuckDBColumnConstraintDefinition :: DuckDBSyntax,
+    duckDBColumnConstraintDefinitionSerialized :: BeamSerializedConstraintDefinition
+  }
+  deriving (Show)
+
+data DuckDBColumnConstraintSyntax = DuckDBColumnConstraintSyntax
+  { fromDuckDBColumnConstraint :: DuckDBSyntax,
+    duckDBColumnConstraintSerialized :: BeamSerializedConstraint
+  }
+
+newtype DuckDBTableConstraintSyntax = DuckDBTableConstraintSyntax {fromDuckDBTableConstraint :: DuckDBSyntax}
+
+data DuckDBMatchTypeSyntax = DuckDBMatchTypeSyntax
+  { fromDuckDBMatchType :: DuckDBSyntax,
+    duckDBMatchTypeSerialized :: BeamSerializedMatchType
+  }
+
+data DuckDBReferentialActionSyntax = DuckDBReferentialActionSyntax
+  { fromDuckDBReferentialAction :: DuckDBSyntax,
+    duckDBReferentialActionSerialized :: BeamSerializedReferentialAction
+  }
+
+newtype DuckDBIndexOptions = DuckDBIndexOptions {duckDBIndexUnique :: Bool}
+  deriving stock (Show, Eq)
+  deriving newtype (Hashable)
 
 newtype DuckDBExtractFieldSyntax = DuckDBExtractFieldSyntax {fromDuckDBExtractField :: DuckDBSyntax}
 
@@ -349,6 +478,293 @@ instance IsSql99DataTypeSyntax DuckDBDataTypeSyntax where
             <> emitChar ')',
         duckDBDataTypeSerialized = rowType (map (second duckDBDataTypeSerialized) fields)
       }
+
+instance IsSql2008BigIntDataTypeSyntax DuckDBDataTypeSyntax where
+  bigIntType = DuckDBDataTypeSyntax (emit "BIGINT") bigIntType
+
+instance IsSql2003BinaryAndVarBinaryDataTypeSyntax DuckDBDataTypeSyntax where
+  binaryType sz =
+    DuckDBDataTypeSyntax
+      (emit "BLOB" <> optPrec sz)
+      (binaryType sz)
+  varBinaryType sz =
+    DuckDBDataTypeSyntax
+      (emit "BLOB" <> optPrec sz)
+      (varBinaryType sz)
+
+-- | Two 'DuckDBDataTypeSyntax' values are equal when their rendered SQL is
+-- equal. This is good enough for migration purposes, where the serialized
+-- JSON form is used as the canonical comparison key by @beam-migrate@.
+instance Eq DuckDBDataTypeSyntax where
+  DuckDBDataTypeSyntax a _ == DuckDBDataTypeSyntax b _ = a == b
+
+instance Hashable DuckDBDataTypeSyntax where
+  hashWithSalt salt (DuckDBDataTypeSyntax a _) = hashWithSalt salt a
+
+instance Sql92DisplaySyntax DuckDBDataTypeSyntax where
+  displaySyntax = displaySyntax . duckDBDataType
+
+instance Sql92SerializableDataTypeSyntax DuckDBDataTypeSyntax where
+  serializeDataType = fromBeamSerializedDataType . duckDBDataTypeSerialized
+
+-- | DuckDB doesn't allow user-defined domain types, so every data type is
+-- always available.
+instance HasDataTypeCreatedCheck DuckDBDataTypeSyntax where
+  dataTypeHasBeenCreated _ _ = True
+
+instance Sql92DisplaySyntax DuckDBColumnSchemaSyntax where
+  displaySyntax = displaySyntax . fromDuckDBColumnSchema
+
+instance Hashable DuckDBColumnSchemaSyntax where
+  hashWithSalt salt = hashWithSalt salt . fromDuckDBColumnSchema
+
+instance Eq DuckDBColumnConstraintDefinitionSyntax where
+  DuckDBColumnConstraintDefinitionSyntax a _ == DuckDBColumnConstraintDefinitionSyntax b _ = a == b
+
+instance Hashable DuckDBColumnConstraintDefinitionSyntax where
+  hashWithSalt salt = hashWithSalt salt . fromDuckDBColumnConstraintDefinition
+
+instance Sql92DisplaySyntax DuckDBColumnConstraintDefinitionSyntax where
+  displaySyntax = displaySyntax . fromDuckDBColumnConstraintDefinition
+
+instance Sql92SerializableConstraintDefinitionSyntax DuckDBColumnConstraintDefinitionSyntax where
+  serializeConstraint = fromBeamSerializedConstraintDefinition . duckDBColumnConstraintDefinitionSerialized
+
+instance IsSql92SchemaNameSyntax DuckDBSchemaNameSyntax where
+  schemaName s = DuckDBSchemaNameSyntax (quotedIdentifier s)
+
+instance IsSql92CreateSchemaSyntax DuckDBCreateSchemaSyntax where
+  type Sql92CreateSchemaSchemaNameSyntax DuckDBCreateSchemaSyntax = DuckDBSchemaNameSyntax
+
+  createSchemaSyntax sNm =
+    DuckDBCreateSchemaSyntax (emit "CREATE SCHEMA " <> fromDuckDBSchemaName sNm)
+
+instance IsSql92DropSchemaSyntax DuckDBDropSchemaSyntax where
+  type Sql92DropSchemaSchemaNameSyntax DuckDBDropSchemaSyntax = DuckDBSchemaNameSyntax
+
+  dropSchemaSyntax sNm =
+    DuckDBDropSchemaSyntax (emit "DROP SCHEMA " <> fromDuckDBSchemaName sNm)
+
+instance IsSql92DropTableSyntax DuckDBDropTableSyntax where
+  type Sql92DropTableTableNameSyntax DuckDBDropTableSyntax = DuckDBTableNameSyntax
+
+  dropTableSyntax tblNm =
+    DuckDBDropTableSyntax (emit "DROP TABLE " <> fromDuckDBTableName tblNm)
+
+instance IsSql92AlterTableSyntax DuckDBAlterTableSyntax where
+  type Sql92AlterTableAlterTableActionSyntax DuckDBAlterTableSyntax = DuckDBAlterTableActionSyntax
+  type Sql92AlterTableTableNameSyntax DuckDBAlterTableSyntax = DuckDBTableNameSyntax
+
+  alterTableSyntax tblNm action =
+    DuckDBAlterTableSyntax $
+      emit "ALTER TABLE "
+        <> fromDuckDBTableName tblNm
+        <> emit " "
+        <> fromDuckDBAlterTableAction action
+
+instance IsSql92AlterTableActionSyntax DuckDBAlterTableActionSyntax where
+  type Sql92AlterTableAlterColumnActionSyntax DuckDBAlterTableActionSyntax = DuckDBAlterColumnActionSyntax
+  type Sql92AlterTableColumnSchemaSyntax DuckDBAlterTableActionSyntax = DuckDBColumnSchemaSyntax
+
+  alterColumnSyntax colNm action =
+    DuckDBAlterTableActionSyntax $
+      emit "ALTER COLUMN "
+        <> quotedIdentifier colNm
+        <> emit " "
+        <> fromDuckDBAlterColumnAction action
+
+  addColumnSyntax colNm schema =
+    DuckDBAlterTableActionSyntax $
+      emit "ADD COLUMN "
+        <> quotedIdentifier colNm
+        <> emit " "
+        <> fromDuckDBColumnSchema schema
+
+  dropColumnSyntax colNm =
+    DuckDBAlterTableActionSyntax (emit "DROP COLUMN " <> quotedIdentifier colNm)
+
+  renameTableToSyntax newNm =
+    DuckDBAlterTableActionSyntax (emit "RENAME TO " <> quotedIdentifier newNm)
+
+  renameColumnToSyntax oldNm newNm =
+    DuckDBAlterTableActionSyntax $
+      emit "RENAME COLUMN "
+        <> quotedIdentifier oldNm
+        <> emit " TO "
+        <> quotedIdentifier newNm
+
+instance IsSql92AlterColumnActionSyntax DuckDBAlterColumnActionSyntax where
+  setNullSyntax = DuckDBAlterColumnActionSyntax (emit "DROP NOT NULL")
+  setNotNullSyntax = DuckDBAlterColumnActionSyntax (emit "SET NOT NULL")
+
+instance IsSql92CreateTableSyntax DuckDBCreateTableSyntax where
+  type Sql92CreateTableTableNameSyntax DuckDBCreateTableSyntax = DuckDBTableNameSyntax
+  type Sql92CreateTableColumnSchemaSyntax DuckDBCreateTableSyntax = DuckDBColumnSchemaSyntax
+  type Sql92CreateTableTableConstraintSyntax DuckDBCreateTableSyntax = DuckDBTableConstraintSyntax
+  type Sql92CreateTableOptionsSyntax DuckDBCreateTableSyntax = DuckDBTableOptionsSyntax
+
+  createTableSyntax options tblNm fieldTypes constraints =
+    let (beforeOptions, afterOptions) =
+          case options of
+            Nothing -> (emit " ", emit " ")
+            Just (DuckDBTableOptionsSyntax before after) ->
+              (emit " " <> before <> emit " ", emit " " <> after <> emit " ")
+     in DuckDBCreateTableSyntax $
+          emit "CREATE"
+            <> beforeOptions
+            <> emit "TABLE "
+            <> fromDuckDBTableName tblNm
+            <> emit " ("
+            <> sepBy
+              (emit ", ")
+              ( map (\(nm, ty) -> quotedIdentifier nm <> emit " " <> fromDuckDBColumnSchema ty) fieldTypes
+                  <> map fromDuckDBTableConstraint constraints
+              )
+            <> emit ")"
+            <> afterOptions
+
+duckDBForeignKeyAction :: ForeignKeyAction -> DuckDBSyntax
+duckDBForeignKeyAction ForeignKeyActionCascade = emit "CASCADE"
+duckDBForeignKeyAction ForeignKeyActionSetNull = emit "SET NULL"
+duckDBForeignKeyAction ForeignKeyActionSetDefault = emit "SET DEFAULT"
+duckDBForeignKeyAction ForeignKeyActionRestrict = emit "RESTRICT"
+duckDBForeignKeyAction ForeignKeyNoAction = emit "NO ACTION"
+
+instance IsSql92TableConstraintSyntax DuckDBTableConstraintSyntax where
+  primaryKeyConstraintSyntax fieldNames =
+    DuckDBTableConstraintSyntax $
+      emit "PRIMARY KEY("
+        <> sepBy (emit ", ") (map quotedIdentifier (NE.toList fieldNames))
+        <> emit ")"
+  foreignKeyConstraintSyntax localCols refTbl refCols onUpdate onDelete =
+    DuckDBTableConstraintSyntax $
+      emit "FOREIGN KEY("
+        <> sepBy (emit ", ") (map quotedIdentifier (NE.toList localCols))
+        <> emit ") REFERENCES "
+        <> quotedIdentifier refTbl
+        <> emit "("
+        <> sepBy (emit ", ") (map quotedIdentifier (NE.toList refCols))
+        <> emit ")"
+        <> emit " ON UPDATE "
+        <> duckDBForeignKeyAction onUpdate
+        <> emit " ON DELETE "
+        <> duckDBForeignKeyAction onDelete
+
+instance IsSql92ColumnSchemaSyntax DuckDBColumnSchemaSyntax where
+  type Sql92ColumnSchemaColumnTypeSyntax DuckDBColumnSchemaSyntax = DuckDBDataTypeSyntax
+  type Sql92ColumnSchemaExpressionSyntax DuckDBColumnSchemaSyntax = DuckDBExpressionSyntax
+  type Sql92ColumnSchemaColumnConstraintDefinitionSyntax DuckDBColumnSchemaSyntax = DuckDBColumnConstraintDefinitionSyntax
+
+  columnSchemaSyntax colType defaultClause constraints collation =
+    DuckDBColumnSchemaSyntax $
+      duckDBDataType colType
+        <> maybe mempty (\d -> emit " DEFAULT " <> fromDuckDBExpression d) defaultClause
+        <> ( case constraints of
+               [] -> mempty
+               _ -> foldMap (\c -> emit " " <> fromDuckDBColumnConstraintDefinition c) constraints
+           )
+        <> maybe mempty (\nm -> emit " COLLATE " <> quotedIdentifier nm) collation
+
+instance IsSql92MatchTypeSyntax DuckDBMatchTypeSyntax where
+  fullMatchSyntax = DuckDBMatchTypeSyntax (emit "FULL") fullMatchSyntax
+  partialMatchSyntax = DuckDBMatchTypeSyntax (emit "PARTIAL") partialMatchSyntax
+
+instance IsSql92ReferentialActionSyntax DuckDBReferentialActionSyntax where
+  referentialActionCascadeSyntax = DuckDBReferentialActionSyntax (emit "CASCADE") referentialActionCascadeSyntax
+  referentialActionNoActionSyntax = DuckDBReferentialActionSyntax (emit "NO ACTION") referentialActionNoActionSyntax
+  referentialActionSetDefaultSyntax = DuckDBReferentialActionSyntax (emit "SET DEFAULT") referentialActionSetDefaultSyntax
+  referentialActionSetNullSyntax = DuckDBReferentialActionSyntax (emit "SET NULL") referentialActionSetNullSyntax
+
+instance IsSql92ColumnConstraintDefinitionSyntax DuckDBColumnConstraintDefinitionSyntax where
+  type Sql92ColumnConstraintDefinitionConstraintSyntax DuckDBColumnConstraintDefinitionSyntax = DuckDBColumnConstraintSyntax
+  type Sql92ColumnConstraintDefinitionAttributesSyntax DuckDBColumnConstraintDefinitionSyntax = SqlConstraintAttributesBuilder
+
+  constraintDefinitionSyntax nm constraint attrs =
+    DuckDBColumnConstraintDefinitionSyntax syntax serialized
+    where
+      syntax =
+        maybe mempty (\n -> emit "CONSTRAINT " <> quotedIdentifier n <> emit " ") nm
+          <> fromDuckDBColumnConstraint constraint
+          <> maybe mempty (\a -> emit " " <> duckDBSqlConstraintAttributes a) attrs
+      serialized =
+        constraintDefinitionSyntax nm (duckDBColumnConstraintSerialized constraint) (fmap sqlConstraintAttributesSerialized attrs)
+
+-- | Emit a 'SqlConstraintAttributesBuilder' as DuckDB syntax. DuckDB does not
+-- support @DEFERRABLE@/@INITIALLY DEFERRED@ at the time of writing, but we
+-- still emit the corresponding SQL keywords so that user-supplied constraint
+-- attributes are not silently dropped. If DuckDB rejects them, the user will
+-- see an obvious error rather than a subtle behavioural difference.
+duckDBSqlConstraintAttributes :: SqlConstraintAttributesBuilder -> DuckDBSyntax
+duckDBSqlConstraintAttributes (SqlConstraintAttributesBuilder timing deferrable) =
+  maybe mempty timingBuilder timing <> maybe mempty deferrableBuilder deferrable
+  where
+    timingBuilder InitiallyDeferred = emit "INITIALLY DEFERRED"
+    timingBuilder InitiallyImmediate = emit "INITIALLY IMMEDIATE"
+    deferrableBuilder False = emit "NOT DEFERRABLE"
+    deferrableBuilder True = emit "DEFERRABLE"
+
+instance IsSql92ColumnConstraintSyntax DuckDBColumnConstraintSyntax where
+  type Sql92ColumnConstraintMatchTypeSyntax DuckDBColumnConstraintSyntax = DuckDBMatchTypeSyntax
+  type Sql92ColumnConstraintReferentialActionSyntax DuckDBColumnConstraintSyntax = DuckDBReferentialActionSyntax
+  type Sql92ColumnConstraintExpressionSyntax DuckDBColumnConstraintSyntax = DuckDBExpressionSyntax
+
+  notNullConstraintSyntax = DuckDBColumnConstraintSyntax (emit "NOT NULL") notNullConstraintSyntax
+  uniqueColumnConstraintSyntax = DuckDBColumnConstraintSyntax (emit "UNIQUE") uniqueColumnConstraintSyntax
+  primaryKeyColumnConstraintSyntax = DuckDBColumnConstraintSyntax (emit "PRIMARY KEY") primaryKeyColumnConstraintSyntax
+  checkColumnConstraintSyntax expr =
+    DuckDBColumnConstraintSyntax
+      (emit "CHECK(" <> fromDuckDBExpression expr <> emit ")")
+      ( checkColumnConstraintSyntax
+          ( BeamSerializedExpression
+              (duckDBRenderSyntaxScript (fromDuckDBExpression expr))
+          )
+      )
+  referencesConstraintSyntax tbl fields matchType onUpdate onDelete =
+    DuckDBColumnConstraintSyntax syntax serialized
+    where
+      syntax =
+        emit "REFERENCES "
+          <> quotedIdentifier tbl
+          <> emit "("
+          <> sepBy (emit ", ") (map quotedIdentifier fields)
+          <> emit ")"
+          <> maybe mempty (\m -> emit " " <> fromDuckDBMatchType m) matchType
+          <> maybe mempty (\a -> emit " ON UPDATE " <> fromDuckDBReferentialAction a) onUpdate
+          <> maybe mempty (\a -> emit " ON DELETE " <> fromDuckDBReferentialAction a) onDelete
+      serialized =
+        referencesConstraintSyntax
+          tbl
+          fields
+          (fmap duckDBMatchTypeSerialized matchType)
+          (fmap duckDBReferentialActionSerialized onUpdate)
+          (fmap duckDBReferentialActionSerialized onDelete)
+
+instance IsSql92CreateDropIndexSyntax DuckDBCommandSyntax where
+  type Sql92CreateIndexOptionsSyntax DuckDBCommandSyntax = DuckDBIndexOptions
+
+  defaultIndexOptions = DuckDBIndexOptions {duckDBIndexUnique = False}
+
+  createIndexCmd idxNm tblNm cols opts =
+    DuckDBCommandSyntax $
+      emit (if duckDBIndexUnique opts then "CREATE UNIQUE INDEX " else "CREATE INDEX ")
+        <> quotedIdentifier idxNm
+        <> emit " ON "
+        <> fromDuckDBTableName tblNm
+        <> parens (sepBy (emit ", ") (NE.toList (fmap quotedIdentifier cols)))
+
+  dropIndexCmd idxNm =
+    DuckDBCommandSyntax (emit "DROP INDEX " <> quotedIdentifier idxNm)
+
+  serializeIndexOptions opts =
+    object ["unique" .= duckDBIndexUnique opts]
+
+  deserializeIndexOptions =
+    withObject "DuckDBIndexOptions" $ \v ->
+      DuckDBIndexOptions <$> v .: "unique"
+
+instance IsSql92UniqueIndexSyntax DuckDBCommandSyntax where
+  setUniqueIndexOptions u opts = opts {duckDBIndexUnique = u}
+  indexIsUnique = duckDBIndexUnique
 
 optPrec :: Maybe Word -> DuckDBSyntax
 optPrec Nothing = mempty

--- a/beam-duckdb/src/Database/Beam/DuckDB/Syntax/Builder.hs
+++ b/beam-duckdb/src/Database/Beam/DuckDB/Syntax/Builder.hs
@@ -19,11 +19,13 @@ module Database.Beam.DuckDB.Syntax.Builder
     commas,
     quotedIdentifier,
     withPlaceholder,
+    duckDBRenderSyntaxScript,
   )
 where
 
 import Data.DList (DList)
 import qualified Data.DList as DL
+import Data.Hashable (Hashable (..))
 import Data.Scientific (Scientific)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -122,6 +124,10 @@ instance Eq DuckDBSyntax where
     -- TODO: is there a cleaner way to do this? Is it even important to have this instance?
     show vx == show vy
       && withPlaceholder sx == withPlaceholder sy
+
+instance Hashable DuckDBSyntax where
+  hashWithSalt salt (DuckDBSyntax s vs) =
+    hashWithSalt salt (Builder.toLazyText (withPlaceholder s), show vs)
 
 instance Semigroup DuckDBSyntax where
   DuckDBSyntax sx vx <> DuckDBSyntax sy vy =

--- a/beam-duckdb/src/Database/Beam/DuckDB/Syntax/Extensions/DataSource.hs
+++ b/beam-duckdb/src/Database/Beam/DuckDB/Syntax/Extensions/DataSource.hs
@@ -96,7 +96,7 @@ csv = flip csvWith defaultCSVOptions
 -- | Declare a CSV file (or files) as the source of data for a database.
 --
 -- See 'csv' if you want to use default options.
--- 
+--
 -- Note: Be careful to sanitize any user input that is then used as
 -- a data source.
 csvWith ::
@@ -138,7 +138,7 @@ defaultCSVOptions =
 -- | Define an Apache Iceberg table with default table options.
 --
 -- See 'icebergTableWith' if you want to change the default options.
--- 
+--
 -- Note: Be careful to sanitize any user input that is then used as
 -- a data source.
 icebergTable ::
@@ -150,7 +150,7 @@ icebergTable = flip icebergTableWith defaultIcebergTableOptions
 -- | Define an Apache Iceberg table with options.
 --
 -- See 'icebergTable' if you want to use default options.
--- 
+--
 -- Note: Be careful to sanitize any user input that is then used as
 -- a data source.
 icebergTableWith ::
@@ -176,7 +176,7 @@ defaultIcebergTableOptions :: IcebergTableOptions
 defaultIcebergTableOptions = IcebergTableOptions Nothing Nothing
 
 -- | Declare a Parquet file(s) or glob(s) as the source of data for a database.
--- 
+--
 -- Note: Be careful to sanitize any user input that is then used as
 -- a data source.
 parquet ::

--- a/beam-duckdb/tests/Database/Beam/DuckDB/Test/Migrate.hs
+++ b/beam-duckdb/tests/Database/Beam/DuckDB/Test/Migrate.hs
@@ -1,0 +1,483 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Database.Beam.DuckDB.Test.Migrate (tests) where
+
+import Control.Arrow ((>>>))
+import Control.Exception (bracket)
+import Control.Monad (void)
+import Data.ByteString (ByteString)
+import Data.Functor ((<&>))
+import Data.Int (Int32, Int8)
+import qualified Data.Text as T
+import Data.UUID.Types (UUID)
+import Data.Word (Word16, Word32, Word64, Word8)
+import Database.Beam
+  ( Beamable,
+    C,
+    Database,
+    Generic,
+    MonadBeam (runNoReturn),
+    Table (..),
+    TableEntity,
+  )
+import Database.Beam.DuckDB (DuckDB, runBeamDuckDB)
+import Database.Beam.DuckDB.Migrate
+  ( blob,
+    getDbConstraints,
+    migrationBackend,
+    text,
+    tinyint,
+    ubigint,
+    uinteger,
+    usmallint,
+    utinyint,
+    uuid,
+  )
+import Database.Beam.Migrate
+  ( CheckedDatabaseSettings,
+    DatabasePredicate (..),
+    Migration,
+    SomeDatabasePredicate (..),
+    addColumn,
+    alterTable,
+    createTable,
+    defaultMigratableDbSettings,
+    dropColumn,
+    executeMigration,
+    field,
+    migrationStep,
+    notNull,
+    runMigrationSteps,
+  )
+import Database.Beam.Migrate.Simple
+  ( VerificationResult (..),
+    autoMigrate,
+    verifySchema,
+  )
+import Database.Beam.Query.DataTypes (double, int, maybeType, varchar)
+import Database.DuckDB.Simple (Connection, execute_)
+import qualified Database.DuckDB.Simple as DuckDB
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, assertBool, assertEqual, assertFailure, testCase, testCaseSteps)
+
+tests :: TestTree
+tests =
+  testGroup
+    "Migration tests"
+    [ verifiesPrimaryKey,
+      verifiesNotNull,
+      verifiesForeignKey,
+      autoMigrateCreatesSchema,
+      autoMigrateIsIdempotent,
+      multiStepMigration,
+      testGroup
+        "Data types"
+        [ duckDBSpecificTypesRoundTrip,
+          duckDBUnsignedIntegersRoundTrip
+        ]
+    ]
+
+withInMemory :: (Connection -> IO a) -> IO a
+withInMemory = bracket (DuckDB.open ":memory:") DuckDB.close
+
+newtype WithPkT f = WithPkT
+  { _with_pk_value :: C f Int32
+  }
+  deriving (Generic, Beamable)
+
+instance Table WithPkT where
+  newtype PrimaryKey WithPkT f = WithPkPk (C f Int32)
+    deriving (Generic, Beamable)
+
+  primaryKey = WithPkPk . _with_pk_value
+
+newtype WithPkDb entity = WithPkDb
+  { _with_pk :: entity (TableEntity WithPkT)
+  }
+  deriving (Generic, Database DuckDB)
+
+withPkDbChecked :: CheckedDatabaseSettings DuckDB WithPkDb
+withPkDbChecked = defaultMigratableDbSettings
+
+verifiesPrimaryKey :: TestTree
+verifiesPrimaryKey =
+  testCase "verifySchema correctly detects primary key" $
+    withInMemory $ \conn -> do
+      void $ execute_ conn "CREATE TABLE with_pk (with_pk_value INTEGER NOT NULL PRIMARY KEY)"
+      runBeamDuckDB conn (verifySchema migrationBackend withPkDbChecked)
+        >>= \case
+          VerificationSucceeded -> pure ()
+          VerificationFailed failures ->
+            assertFailure $ "Verification failed: " ++ show failures
+
+newtype NotNullT f = NotNullT
+  { _nn_value :: C f T.Text
+  }
+  deriving (Generic, Beamable)
+
+instance Table NotNullT where
+  newtype PrimaryKey NotNullT f = NotNullPk (C f T.Text)
+    deriving (Generic, Beamable)
+
+  primaryKey = NotNullPk . _nn_value
+
+newtype NotNullDb entity = NotNullDb
+  { _nn_tbl :: entity (TableEntity NotNullT)
+  }
+  deriving (Generic, Database DuckDB)
+
+notNullDbChecked :: CheckedDatabaseSettings DuckDB NotNullDb
+notNullDbChecked = defaultMigratableDbSettings
+
+verifiesNotNull :: TestTree
+verifiesNotNull =
+  testCase "verifySchema correctly detects NOT NULL columns" $
+    withInMemory $ \conn -> do
+      void $
+        execute_
+          conn
+          "CREATE TABLE nn_tbl (nn_value VARCHAR NOT NULL PRIMARY KEY)"
+      runBeamDuckDB conn (verifySchema migrationBackend notNullDbChecked)
+        >>= \case
+          VerificationSucceeded -> pure ()
+          VerificationFailed failures ->
+            assertFailure $ "Verification failed: " ++ show failures
+
+newtype FkParentT f = FkParentT
+  { _fk_parent_id :: C f Int32
+  }
+  deriving (Generic, Beamable)
+
+instance Table FkParentT where
+  newtype PrimaryKey FkParentT f = FkParentPk (C f Int32)
+    deriving (Generic, Beamable)
+  primaryKey = FkParentPk . _fk_parent_id
+
+data FkChildT f = FkChildT
+  { _fk_child_id :: C f Int32,
+    _fk_child_parent_id :: PrimaryKey FkParentT f
+  }
+  deriving (Generic, Beamable)
+
+instance Table FkChildT where
+  newtype PrimaryKey FkChildT f = FkChildPk (C f Int32)
+    deriving (Generic, Beamable)
+  primaryKey = FkChildPk . _fk_child_id
+
+data FkDb entity = FkDb
+  { _fk_parent :: entity (TableEntity FkParentT),
+    _fk_child :: entity (TableEntity FkChildT)
+  }
+  deriving (Generic, Database DuckDB)
+
+verifiesForeignKey :: TestTree
+verifiesForeignKey =
+  testCase "getDbConstraints sees both parent and child tables" $
+    withInMemory $ \conn -> do
+      void $
+        execute_
+          conn
+          "CREATE TABLE fk_parent (fk_parent_id INTEGER NOT NULL PRIMARY KEY)"
+      void $
+        execute_
+          conn
+          "CREATE TABLE fk_child (\
+          \  fk_child_id INTEGER NOT NULL PRIMARY KEY,\
+          \  fk_child_parent_id INTEGER NOT NULL,\
+          \  FOREIGN KEY (fk_child_parent_id) REFERENCES fk_parent (fk_parent_id))"
+      preds <- runBeamDuckDB conn getDbConstraints
+      assertBool "should see fk_parent in predicates" $
+        any (predicateNamesTable "fk_parent") preds
+      assertBool "should see fk_child in predicates" $
+        any (predicateNamesTable "fk_child") preds
+  where
+    predicateNamesTable :: T.Text -> SomeDatabasePredicate -> Bool
+    predicateNamesTable name (SomeDatabasePredicate p) =
+      name `T.isInfixOf` T.pack (englishDescription p)
+
+autoMigrateCreatesSchema :: TestTree
+autoMigrateCreatesSchema =
+  testCase "autoMigrate creates a schema that round-trips through verifySchema" $
+    withInMemory $ \conn -> do
+      runBeamDuckDB conn $ autoMigrate migrationBackend withPkDbChecked
+      runBeamDuckDB conn (verifySchema migrationBackend withPkDbChecked)
+        >>= \case
+          VerificationSucceeded -> pure ()
+          VerificationFailed failures ->
+            assertFailure $ "Verification failed: " ++ show failures
+      preds <- runBeamDuckDB conn getDbConstraints
+      assertBool "should see with_pk table after autoMigrate" $
+        any (predicateNamesTable "with_pk") preds
+  where
+    predicateNamesTable :: T.Text -> SomeDatabasePredicate -> Bool
+    predicateNamesTable name (SomeDatabasePredicate p) =
+      name `T.isInfixOf` T.pack (englishDescription p)
+
+autoMigrateIsIdempotent :: TestTree
+autoMigrateIsIdempotent =
+  testCase "autoMigrate is idempotent" $
+    withInMemory $ \conn -> do
+      runBeamDuckDB conn $ autoMigrate migrationBackend withPkDbChecked
+      runBeamDuckDB conn $ autoMigrate migrationBackend withPkDbChecked
+      runBeamDuckDB conn (verifySchema migrationBackend withPkDbChecked) >>= \case
+        VerificationSucceeded -> pure ()
+        VerificationFailed failures ->
+          assertFailure $ "Verification failed: " ++ show failures
+
+data TypesT f = TypesT
+  { _types_pk :: C f Int32,
+    _types_text :: C f T.Text,
+    _types_blob :: C f ByteString,
+    _types_tinyint :: C f Int8,
+    _types_uuid :: C f UUID
+  }
+  deriving (Generic, Beamable)
+
+instance Table TypesT where
+  newtype PrimaryKey TypesT f = TypesPk (C f Int32)
+    deriving (Generic, Beamable)
+  primaryKey = TypesPk . _types_pk
+
+newtype TypesDb entity = TypesDb
+  { _types_tbl :: entity (TableEntity TypesT)
+  }
+  deriving (Generic, Database DuckDB)
+
+duckDBSpecificTypesRoundTrip :: TestTree
+duckDBSpecificTypesRoundTrip =
+  testCase "verifySchema round-trips schemas that use text/blob/tinyint/uuid" $
+    withInMemory $ \conn -> do
+      -- Create the table directly with the DuckDB-specific keywords. The
+      -- schema we'll verify against, defined below via 'createTable' + 'field',
+      -- should round-trip cleanly against information_schema.
+      void $
+        execute_
+          conn
+          "CREATE TABLE types_tbl (\
+          \ types_pk INTEGER NOT NULL PRIMARY KEY,\
+          \ types_text TEXT NOT NULL,\
+          \ types_blob BLOB NOT NULL,\
+          \ types_tinyint TINYINT NOT NULL,\
+          \ types_uuid UUID NOT NULL)"
+      let dsl = do
+            typesTbl <-
+              createTable
+                "types_tbl"
+                TypesT
+                  { _types_pk = field "types_pk" int notNull,
+                    _types_text = field "types_text" text notNull,
+                    _types_blob = field "types_blob" blob notNull,
+                    _types_tinyint = field "types_tinyint" tinyint notNull,
+                    _types_uuid = field "types_uuid" uuid notNull
+                  }
+            pure (TypesDb typesTbl)
+      -- Drop the table so executeMigration can re-create it from the DSL,
+      -- then verify it matches. This is the standard 'beam-migrate' flow.
+      void $ execute_ conn "DROP TABLE types_tbl"
+      result <- runBeamDuckDB conn $ do
+        db <- executeMigration runNoReturn dsl
+        verifySchema migrationBackend db
+      case result of
+        VerificationSucceeded -> pure ()
+        VerificationFailed failures ->
+          assertFailure $ "Verification failed: " ++ show failures
+
+data UIntsT f = UIntsT
+  { _uints_pk :: C f Int32,
+    _uints_utiny :: C f Word8,
+    _uints_usmall :: C f Word16,
+    _uints_uint :: C f Word32,
+    _uints_ubig :: C f Word64
+  }
+  deriving (Generic, Beamable)
+
+instance Table UIntsT where
+  newtype PrimaryKey UIntsT f = UIntsPk (C f Int32)
+    deriving (Generic, Beamable)
+  primaryKey = UIntsPk . _uints_pk
+
+newtype UIntsDb entity = UIntsDb
+  { _uints_tbl :: entity (TableEntity UIntsT)
+  }
+  deriving (Generic, Database DuckDB)
+
+duckDBUnsignedIntegersRoundTrip :: TestTree
+duckDBUnsignedIntegersRoundTrip =
+  testCase "verifySchema round-trips schemas that use utinyint/usmallint/uinteger/ubigint" $
+    withInMemory $ \conn -> do
+      let dsl = do
+            uintsTbl <-
+              createTable
+                "uints_tbl"
+                UIntsT
+                  { _uints_pk = field "uints_pk" int notNull,
+                    _uints_utiny = field "uints_utiny" utinyint notNull,
+                    _uints_usmall = field "uints_usmall" usmallint notNull,
+                    _uints_uint = field "uints_uint" uinteger notNull,
+                    _uints_ubig = field "uints_ubig" ubigint notNull
+                  }
+            pure (UIntsDb uintsTbl)
+      result <- runBeamDuckDB conn $ do
+        db <- executeMigration runNoReturn dsl
+        verifySchema migrationBackend db
+      case result of
+        VerificationSucceeded -> pure ()
+        VerificationFailed failures ->
+          assertFailure $ "Verification failed: " ++ show failures
+
+data WidgetsV1T f = WidgetsV1T
+  { _v1_id :: C f Int32,
+    _v1_name :: C f T.Text
+  }
+  deriving (Generic, Beamable)
+
+instance Table WidgetsV1T where
+  newtype PrimaryKey WidgetsV1T f = WidgetsV1Pk (C f Int32)
+    deriving (Generic, Beamable)
+  primaryKey = WidgetsV1Pk . _v1_id
+
+data WidgetsV2T f = WidgetsV2T
+  { _v2_id :: C f Int32,
+    _v2_name :: C f T.Text,
+    -- widgets gains a nullable 'price' column. DuckDB rejects
+    -- @ALTER TABLE ... ADD COLUMN ... <constraint>@ with the parser error
+    -- "Adding columns with constraints not yet supported", so the added
+    -- column is nullable here.
+    _v2_price :: C f (Maybe Double)
+  }
+  deriving (Generic, Beamable)
+
+instance Table WidgetsV2T where
+  newtype PrimaryKey WidgetsV2T f = WidgetsV2Pk (C f Int32)
+    deriving (Generic, Beamable)
+  primaryKey = WidgetsV2Pk . _v2_id
+
+newtype WidgetsV1Db entity = WidgetsV1Db
+  { _v1_widgets :: entity (TableEntity WidgetsV1T)
+  }
+  deriving (Generic, Database DuckDB)
+
+newtype WidgetsV2Db entity = WidgetsV2Db
+  { _v2_widgets :: entity (TableEntity WidgetsV2T)
+  }
+  deriving (Generic, Database DuckDB)
+
+stepV1 :: () -> Migration DuckDB (CheckedDatabaseSettings DuckDB WidgetsV1Db)
+stepV1 () =
+  WidgetsV1Db
+    <$> createTable
+      "widgets"
+      WidgetsV1T
+        { _v1_id = field "id" int notNull,
+          _v1_name = field "name" (varchar Nothing) notNull
+        }
+
+stepV2 ::
+  CheckedDatabaseSettings DuckDB WidgetsV1Db ->
+  Migration DuckDB (CheckedDatabaseSettings DuckDB WidgetsV2Db)
+stepV2 oldDb =
+  WidgetsV2Db
+    <$> alterTable
+      (_v1_widgets oldDb)
+      ( \oldTbl -> do
+          price <- addColumn (field "price" (maybeType double))
+          pure
+            WidgetsV2T
+              { _v2_id = _v1_id oldTbl,
+                _v2_name = _v1_name oldTbl,
+                _v2_price = price
+              }
+      )
+
+stepV3 ::
+  CheckedDatabaseSettings DuckDB WidgetsV2Db ->
+  Migration DuckDB (CheckedDatabaseSettings DuckDB WidgetsV1Db)
+stepV3 (WidgetsV2Db v2Table) =
+  WidgetsV1Db
+    <$> alterTable
+      v2Table
+      ( \v2Table' -> do
+          dropColumn (_v2_price v2Table')
+          pure (WidgetsV1T (_v2_id v2Table') (_v2_name v2Table'))
+      )
+
+runVerifySchema ::
+  (Database DuckDB db) =>
+  Connection ->
+  CheckedDatabaseSettings DuckDB db ->
+  Assertion
+runVerifySchema conn db =
+  runBeamDuckDB conn (verifySchema migrationBackend db) >>= \case
+    VerificationSucceeded -> pure ()
+    VerificationFailed failures ->
+      assertFailure $ "Verification failed: " ++ show failures
+
+multiStepMigration :: TestTree
+multiStepMigration =
+  testCaseSteps "two-step migration: create + alter table verifies against final schema" $ \testStep ->
+    withInMemory $ \conn -> do
+      let getColumns =
+            ( DuckDB.query_
+                conn
+                "SELECT column_name FROM information_schema.columns \
+                \WHERE table_name = 'widgets' \
+                \ORDER BY ordinal_position" ::
+                IO [DuckDB.Only T.Text]
+            )
+              <&> map (\(DuckDB.Only c) -> c)
+
+      testStep "Initial migration"
+      v1Db <- runBeamDuckDB conn $
+        runMigrationSteps 0 Nothing (migrationStep "V1" stepV1) $ \_ _ step ->
+          executeMigration runNoReturn step
+      runVerifySchema conn v1Db
+
+      getColumns >>= \cols ->
+        assertEqual
+          ("expected 'price' in columns " ++ show cols)
+          ["id", "name"]
+          cols
+
+      testStep "Migration across V1 and V2"
+      v2Db <- runBeamDuckDB conn
+        $ runMigrationSteps
+          1
+          Nothing
+          ( migrationStep "V1" stepV1
+              >>> migrationStep "V2" stepV2
+          )
+        $ \_ _ step ->
+          executeMigration runNoReturn step
+      runVerifySchema conn v2Db
+
+      getColumns >>= \cols ->
+        assertEqual
+          ("expected 'price' in columns " ++ show cols)
+          ["id", "name", "price"]
+          cols
+
+      testStep "Migration back to V1"
+      v3Db <- runBeamDuckDB conn
+        $ runMigrationSteps
+          2
+          Nothing
+          ( migrationStep "V1" stepV1
+              >>> migrationStep "V2" stepV2
+              >>> migrationStep "V3" stepV3
+          )
+        $ \_ _ step ->
+          executeMigration runNoReturn step
+      runVerifySchema conn v3Db
+
+      getColumns >>= \cols ->
+        assertEqual
+          ("expected price column dropped, in columns " ++ show cols)
+          ["id", "name"]
+          cols

--- a/beam-duckdb/tests/Main.hs
+++ b/beam-duckdb/tests/Main.hs
@@ -1,6 +1,7 @@
 module Main (main) where
 
 import qualified Database.Beam.DuckDB.Test.Extensions (tests)
+import qualified Database.Beam.DuckDB.Test.Migrate (tests)
 import qualified Database.Beam.DuckDB.Test.Query (tests)
 import Test.Tasty (defaultMain, testGroup)
 
@@ -10,5 +11,6 @@ main =
     testGroup
       "beam-duckdb tests"
       [ Database.Beam.DuckDB.Test.Query.tests,
-        Database.Beam.DuckDB.Test.Extensions.tests
+        Database.Beam.DuckDB.Test.Extensions.tests,
+        Database.Beam.DuckDB.Test.Migrate.tests
       ]


### PR DESCRIPTION
This pull request exposes a new module, `Database.Beam.DuckDB.Migrate`, which allows the migration framework from `beam-migrate` to work with `beam-duckdb`. 