### PR TITLE
docs: document beam-large-records

### DIFF
--- a/docs/user-guide/models.md
+++ b/docs/user-guide/models.md
@@ -9,6 +9,29 @@ type with a `Beamable` instance) or an explicit column. A column is specified
 using the `Columnar` type family applied to the type's parameter and the
 underlying Haskell type of the field.
 
+## Schemas with many fields
+
+For schemas with many fields, the separate
+[`beam-large-records`](https://github.com/well-typed/large-records/tree/main/beam-large-records)
+package can reduce compilation time. It integrates Beam with
+`large-records` so that records marked with
+[`largeRecord`](https://hackage.haskell.org/package/large-records/docs/Data-Record-Plugin.html#v:largeRecord)
+can derive `Beamable`.
+
+Add `large-records`, `ghc-prim`, `large-generics`, `record-hasfield`, and
+`beam-large-records` to your build dependencies. Then enable the `large-records`
+plugin and import the Beam integration for its instances:
+
+```haskell
+{-# OPTIONS_GHC -fplugin=Data.Record.Plugin #-}
+
+import Data.Record.Beam ()
+
+{-# ANN type UserT largeRecord #-}
+```
+
+You can then define the `Table` and `Database` instances as usual.
+
 ## The `Table` type class
 
 `Table` is a type class that must be instantiated for all types that you would

--- a/docs/user-guide/models.md
+++ b/docs/user-guide/models.md
@@ -11,10 +11,19 @@ underlying Haskell type of the field.
 
 ## Schemas with many fields
 
-For schemas with many fields, the separate
+There is no fixed field-count cutoff: the benefit depends on the instances
+derived for the record, the GHC version, and the rest of the module. In the
+upstream [`large-records` benchmark](https://github.com/well-typed/large-records/tree/main/large-records-benchmarks/report),
+measured with GHC 8.8.4 and `-O0`, a module containing a synthetic 20-field
+record with `Eq`, `Show`, `Generic`, `HasField`, and `ToJSON` support compiled
+in 318 ms before and 80 ms with `large-records` (about 75% less); at 100 fields,
+the corresponding times were 2.28 s and 444 ms (about 81% less). Because this
+benchmark is not Beam-specific, profile your own schema rather than treating
+20 fields as a threshold.
+
+The separate
 [`beam-large-records`](https://github.com/well-typed/large-records/tree/main/beam-large-records)
-package can reduce compilation time. It integrates Beam with
-`large-records` so that records marked with
+package integrates Beam with `large-records` so that records marked with
 [`largeRecord`](https://hackage.haskell.org/package/large-records/docs/Data-Record-Plugin.html#v:largeRecord)
 can derive `Beamable`.
 


### PR DESCRIPTION
## Summary

- document when `beam-large-records` is useful for schemas with many fields
- show the plugin, integration import, and `largeRecord` annotation
- list the direct dependencies required by the plugin and link authoritative package documentation

Closes #825.

## Validation

- verified the package metadata and example against the official `beam-large-records` source
- verified the quoted benchmark values against the upstream timing data and methodology
- verified all three added links resolve
- checked Markdown fence balance
- `git diff --check`

The repository's `nix build .#docs -L` check was not available locally because Nix is not installed.